### PR TITLE
修复首次扫码登录无法创建微信读书 Skills API Key

### DIFF
--- a/miuread.koplugin/miuread/auth.lua
+++ b/miuread.koplugin/miuread/auth.lua
@@ -33,6 +33,9 @@ end
 local function merge_auth_headers(jar,vid,key)
     return {Accept="application/json, text/plain, */*",Referer=BASE.."/r/weread-skills",Cookie=Cookies.header(jar),["X-Vid"]=vid,["X-Skey"]=key}
 end
+local function skill_api_key(value)
+    return type(value)=="table" and type(value.apikey)=="string" and value.apikey or ""
+end
 function Auth:_close_dialog()
     if not self.dialog then return end
     local d=self.dialog; self.dialog=nil; self.closing=true; UIManager:close(d); self.closing=false
@@ -78,7 +81,15 @@ function Auth:_finish(data)
     jar=Cookies.absorb(jar,header_value(user_headers,"set-cookie"))
     local skill,skill_headers=self.http:get_json(BASE.."/api/skills/apikeyGet?only_show=1",{auth=false,headers=merge_auth_headers(jar,vid,key)})
     jar=Cookies.absorb(jar,header_value(skill_headers,"set-cookie"))
-    local api_key=tostring(skill.apikey or ""); if api_key=="" then error("No WeRead Skill API key returned") end
+    local api_key=skill_api_key(skill)
+    if api_key=="" then
+        -- only_show=1 never creates a key. New Skills users receive
+        -- { isEmpty = true } until the creation endpoint is requested.
+        skill,skill_headers=self.http:get_json(BASE.."/api/skills/apikeyGet",{auth=false,headers=merge_auth_headers(jar,vid,key)})
+        jar=Cookies.absorb(jar,header_value(skill_headers,"set-cookie"))
+        api_key=skill_api_key(skill)
+    end
+    if api_key=="" then error("No WeRead Skill API key returned") end
     self.store:save_auth({api_key=api_key,cookies=jar,account={name=tostring(user.name or ""),vid=vid,logged_at=os.time()}})
     logger.info("[MiuRead][Auth] stable cookies saved", "names=", table.concat(Cookies.names(jar), ","))
     return user.name or vid

--- a/miuread.koplugin/miuread/legacy/client.lua
+++ b/miuread.koplugin/miuread/legacy/client.lua
@@ -512,6 +512,14 @@ function Client:complete_qr_login(login_result)
     )
     local api_key = type(api_result.apikey) == "string" and api_result.apikey or ""
     if api_key == "" then
+        -- only_show=1 reports an empty result for accounts that have never
+        -- created a Skills API key. Calling the base endpoint creates it.
+        api_result, cookies = authenticated_get_json(
+            self, API_KEY_URL, cookies, web_login_vid, access_token
+        )
+        api_key = type(api_result.apikey) == "string" and api_result.apikey or ""
+    end
+    if api_key == "" then
         error("WeRead did not return an API key")
     end
 


### PR DESCRIPTION
## 背景

部分用户在 KOReader 中完成微信读书扫码授权后，插件仍提示：

```text
No WeRead Skill API key returned
```

该问题主要发生在第一次使用微信读书 Skills、账号尚未创建 API Key 的场景。二维码授权本身已经成功，但插件在读取 API Key 时中止了后续登录流程。

## 根本原因

插件原先只请求：

```text
/api/skills/apikeyGet?only_show=1
```

`only_show=1` 只用于读取已有的 API Key，不会为首次使用的账号创建 Key。尚未创建 Key 的账号会得到空结果（例如 `isEmpty`），原逻辑将这种正常的首次使用状态直接当成登录失败。

微信读书 Skills 页面在用户创建 Key 时，会请求不带 `only_show=1` 的基础接口：

```text
/api/skills/apikeyGet
```

因此扫码登录流程需要在“读取结果为空”时补一次基础接口请求。

## 修改内容

### 1. 当前扫码登录实现

- 保留原有的只读查询，已有 API Key 的账号继续直接使用现有 Key；
- 新增统一的 API Key 提取函数，安全处理空值和非预期返回结构；
- 当只读查询未返回 `apikey` 时，请求基础接口创建账号的首个 Key；
- 继续吸收两次请求返回的 `Set-Cookie`，保证后续认证信息完整；
- 创建请求后仍未获得 Key 时保留明确错误，不保存无效登录状态。

### 2. Legacy 扫码登录实现

- 对 legacy client 应用相同的“先查询、为空时再创建”逻辑；
- 确保两套扫码入口的首次登录行为一致；
- 已有 Key 的账号不会触发创建请求，也不会旋转或覆盖现有 Key。

## 用户影响

- 首次使用微信读书 Skills 的账号可以直接完成 KOReader 扫码登录；
- 不需要先手动打开 Skills 网页创建 API Key；
- 已经存在 API Key 的账号行为保持不变；
- 二维码授权、Cookie 保存和账号信息保存流程保持原有兼容性。

## 提交范围

- 仅修改插件中的两个 Lua 文件：
  - `miuread.koplugin/miuread/auth.lua`
  - `miuread.koplugin/miuread/legacy/client.lua`
- 不包含账号 Cookie、API Key、设备配置、日志或其他本地测试数据；
- 不包含书籍、EPUB、阅读记录或样式相关改动。

## 通用测试

- 使用 `luaparse` 检查两个改动 Lua 文件，语法通过；
- 使用模拟扫码完成流程验证已有 Key 的场景：
  - 只执行一次 `only_show=1` 只读查询；
  - 直接保存返回的现有 Key；
  - 不调用创建接口；
- 使用模拟扫码完成流程验证首次无 Key 的场景：
  - 第一次只读查询返回空结果；
  - 随后执行一次基础接口请求；
  - 保存创建接口返回的 Key；
- 验证当前实现和 legacy 实现均采用相同行为；
- 验证创建接口仍未返回 Key 时继续抛出错误，不保存空 Key。

## 兼容性说明

- 创建请求仅在只读查询没有返回有效 `apikey` 时发生；
- 已有账号不会重复创建、更新或轮换 API Key；
- 没有修改二维码轮询、用户信息获取、认证持久化格式或其他 API 协议。
