### PR TITLE
统一划线样式并优化阅读排版和想法弹窗

### DIFF
--- a/miuread.koplugin/main.lua
+++ b/miuread.koplugin/main.lua
@@ -1644,6 +1644,42 @@ function Plugin:_thought_font_size(level)
     local factor=factors[tostring(level or "standard")] or 1
     return Device.screen:scaleBySize(math.floor(base*factor+.5))
 end
+function Plugin:_thought_font_face()
+    local ui=self.ui
+    local face=ui and ui.font and ui.font.font_face
+    if type(face)=="string" and U.trim(face)~="" then return U.trim(face) end
+    local doc=ui and ui.document
+    if doc and type(doc.getFontFace)=="function" then
+        local ok,value=pcall(doc.getFontFace,doc)
+        if ok and type(value)=="string" and U.trim(value)~="" then return U.trim(value) end
+    end
+    if _G.G_reader_settings and _G.G_reader_settings.readSetting then
+        local ok,value=pcall(_G.G_reader_settings.readSetting,_G.G_reader_settings,"cre_font")
+        if ok and type(value)=="string" and U.trim(value)~="" then return U.trim(value) end
+    end
+    return "serif"
+end
+function Plugin:_thought_popup_css()
+    local face=self:_thought_font_face()
+    local definitions,seen={},{ }
+    local ok,cre=pcall(function() return require("document/credocument"):engineInit() end)
+    if ok and cre and type(cre.getFontFaceFilenameAndFaceIndex)=="function" then
+        for index=1,4 do
+            local bold=index>=3
+            local italic=index==2 or index==4
+            local got,path=pcall(cre.getFontFaceFilenameAndFaceIndex,face,bold,italic)
+            if got and type(path)=="string" and path~="" and not seen[path] then
+                seen[path]=true
+                local safe=path:gsub("\\","\\\\"):gsub('"','\\"'):gsub("[%c]","")
+                definitions[#definitions+1]='@font-face{font-family:"MiuReadThoughtFont";src:url("'..safe..'")'
+                    ..(bold and ";font-weight:bold" or "")
+                    ..(italic and ";font-style:italic" or "").."}"
+            end
+        end
+    end
+    if #definitions>0 then face="MiuReadThoughtFont" end
+    return Thoughts.popup_css(face,table.concat(definitions,"\n"))
+end
 function Plugin:_show_thought_href(href)
     local info=Thoughts.parse_href(href); if not info then return false end
     local group,err=Thoughts.find(self.store,info.book_id,info.chapter_uid,info.range)
@@ -1657,7 +1693,7 @@ function Plugin:_show_thought_href(href)
         font_size=self:_thought_font_size(prefs.font),
         width_ratio=tonumber(prefs.width_ratio) or 0.91,
         height_ratio=tonumber(prefs.height_ratio) or 0.60,
-        css=Thoughts.popup_css(),
+        css=self:_thought_popup_css(),
         metrics=metrics,
     }
     return true

--- a/miuread.koplugin/miuread/annotation_style.lua
+++ b/miuread.koplugin/miuread/annotation_style.lua
@@ -1,26 +1,30 @@
 local M = {}
 
-M.MARKER_BEGIN = "/* MIUREAD_ANNOTATION_STYLE_V2_BEGIN */"
-M.MARKER_END = "/* MIUREAD_ANNOTATION_STYLE_V2_END */"
+M.MARKER_BEGIN = "/* MIUREAD_ANNOTATION_STYLE_V4_BEGIN */"
+M.MARKER_END = "/* MIUREAD_ANNOTATION_STYLE_V4_END */"
+M.LINK_INLINE_STYLE = "text-decoration:none; border-bottom:0; color:inherit;"
+M.MARK_INLINE_STYLE = "text-decoration:none; border-bottom:2px dashed #555; padding-bottom:2px; color:inherit;"
 
--- Keep this intentionally close to the proven weread implementation.
--- The thought text uses its own class, so it can never inherit the solid
--- underline rule used by ordinary WeRead marks.
+-- Use one unmistakable style for every WeRead mark. Publisher styles and
+-- KOReader's default link decoration must not turn thought links into solid
+-- or double underlines.
 M.CSS = [[
-/* MIUREAD_ANNOTATION_STYLE_V2_BEGIN */
+/* MIUREAD_ANNOTATION_STYLE_V4_BEGIN */
 .miu-inline-mark {
-    text-decoration: underline;
+    text-decoration: none;
+    border-bottom: 2px dashed #555;
+    padding-bottom: 2px;
 }
 .miu-thought-link {
     text-decoration: none;
-    color: inherit;
-}
-.miu-thought-link .miu-thought-mark {
+    border-bottom: 0;
     color: inherit;
 }
 .miu-thought-mark {
-    border-bottom: 2px dashed #ff6b35;
+    text-decoration: none;
+    border-bottom: 2px dashed #555;
     padding-bottom: 2px;
+    color: inherit;
 }
 .miu-thought-star {
     font-size: 0;
@@ -29,11 +33,14 @@ M.CSS = [[
     padding: 0;
     color: transparent;
 }
-/* MIUREAD_ANNOTATION_STYLE_V2_END */
+/* MIUREAD_ANNOTATION_STYLE_V4_END */
 ]]
 
 local OLD_MARKERS = {
     {"/* MIUREAD_ANNOTATION_STYLE_REPAIR_BEGIN */", "/* MIUREAD_ANNOTATION_STYLE_REPAIR_END */"},
+    {"/* MIUREAD_ANNOTATION_STYLE_V2_BEGIN */", "/* MIUREAD_ANNOTATION_STYLE_V2_END */"},
+    {"/* MIUREAD_ANNOTATION_STYLE_V3_BEGIN */", "/* MIUREAD_ANNOTATION_STYLE_V3_END */"},
+    {"/* MIUREAD_UNIFIED_DASHED_MARKS_BEGIN */", "/* MIUREAD_UNIFIED_DASHED_MARKS_END */"},
     {M.MARKER_BEGIN, M.MARKER_END},
 }
 
@@ -150,11 +157,10 @@ end
 
 function M.css_is_current(css)
     css = tostring(css or "")
-    return css:find(M.MARKER_BEGIN, 1, true) ~= nil
-        and css:find(".miu-thought-mark", 1, true) ~= nil
-        and css:find("border-bottom: 2px dashed #ff6b35;", 1, true) ~= nil
-        and css:find(".miu-inline-mark.miu-has-thought", 1, true) == nil
-        and css:find(".miu-thought-link .miu-inline-mark", 1, true) == nil
+    local rewritten = M.rewrite_css(css)
+    return rewritten == css
+        and css:find(M.MARKER_BEGIN, 1, true) ~= nil
+        and css:find("border-bottom: 2px dashed #555;", 1, true) ~= nil
 end
 
 return M

--- a/miuread.koplugin/miuread/annotations.lua
+++ b/miuread.koplugin/miuread/annotations.lua
@@ -444,12 +444,15 @@ local function render_text_token(token, marks, data)
             if active then
                 if active.thought then
                     local href = Thoughts.href(data.book_id, data.chapter_uid, active.key)
-                    out[#out + 1] = '<a class="miu-thought-link" href="' .. href .. '">'
+                    out[#out + 1] = '<a class="miu-thought-link" style="' .. AnnotationStyle.LINK_INLINE_STYLE
+                        .. '" href="' .. href .. '">'
                     active_id_written = true
                 end
                 local mark_class = Thoughts.mark_class(active.key)
                 local display_class = active.thought and "miu-thought-mark" or "miu-inline-mark"
-                out[#out + 1] = '<span class="' .. display_class .. ' ' .. mark_class .. '" data-miu-range="' .. active.key .. '">'
+                out[#out + 1] = '<span class="' .. display_class .. ' ' .. mark_class
+                    .. '" style="' .. AnnotationStyle.MARK_INLINE_STYLE .. '" data-miu-range="'
+                    .. active.key .. '">'
             end
         end
         out[#out + 1] = unit

--- a/miuread.koplugin/miuread/downloader.lua
+++ b/miuread.koplugin/miuread/downloader.lua
@@ -2,6 +2,7 @@ local Protocol = require("miuread.protocol")
 local Codec = require("miuread.codec")
 local Footnotes = require("miuread.footnotes")
 local Thoughts = require("miuread.thoughts")
+local AnnotationStyle = require("miuread.annotation_style")
 local Epub = require("miuread.epub")
 local Json = require("miuread.json")
 local U = require("miuread.util")
@@ -18,10 +19,35 @@ Downloader.__index = Downloader
 local CACHE_SCHEMA = 5
 
 local BASE_CSS = [[
-body { line-height: 1.75; margin: 5%; }
+body { margin: 0; }
 img { max-width: 100%; height: auto; }
 .miu-chapter { display: block; page-break-before: always; break-before: page; }
 .miu-chapter-title { font-size: 1.55em; font-weight: bold; line-height: 1.35; margin: 1.2em 0 .9em 0; page-break-before: always; break-before: page; }
+]]
+
+-- WeRead serves publisher CSS for regular books, while official-account
+-- collections arrive as lightly styled HTML. Apply one final typography layer
+-- after both paths so KOReader remains in charge of the reading font, line
+-- spacing and CJK width/word spacing. Structural styles (alignment, indents,
+-- headings, images and page breaks) are intentionally preserved.
+local READER_CONTROL_CSS = [[
+/* MIUREAD_READER_CONTROL_BEGIN */
+html, body, article, section, div, p, span, li, blockquote,
+h1, h2, h3, h4, h5, h6, td, th {
+    font-family: inherit !important;
+    letter-spacing: normal !important;
+    word-spacing: normal !important;
+}
+body {
+    margin: 0 !important;
+    padding: 0 !important;
+    line-height: normal !important;
+}
+p, div, article, section, li, blockquote, td, th {
+    line-height: inherit !important;
+}
+pre, code, kbd, samp { font-family: monospace !important; }
+/* MIUREAD_READER_CONTROL_END */
 ]]
 
 local function normalized_book(value)
@@ -39,6 +65,18 @@ end
 local function css_add(list, seen, css)
     css = tostring(css or "")
     if css ~= "" and not seen[css] then seen[css] = true; list[#list + 1] = css end
+end
+
+local function final_css(list, seen)
+    css_add(list, seen, READER_CONTROL_CSS)
+    -- A publisher may return a slightly different full stylesheet for each
+    -- chapter. Concatenating those styles also concatenates the annotation
+    -- rules, so a stale solid-underline rule can end up after the dashed one.
+    -- Normalize the completed stylesheet once, after every chapter style has
+    -- been collected, leaving exactly one annotation block at the true end.
+    local css = table.concat(list, "\n")
+    local rewritten = AnnotationStyle.rewrite_css(css)
+    return rewritten
 end
 
 local function plain(value)
@@ -816,7 +854,7 @@ function Downloader:book(input, opt, progress)
         progress("package", #chapters, expected, book.title)
         opt.expected_chapter_count = expected
         opt.checkpointed = true
-        local record = self:_save(book, chapters, assets, table.concat(css_list, "\n"), self:_cover(book, true), opt, failures, session)
+        local record = self:_save(book, chapters, assets, final_css(css_list, css_seen), self:_cover(book, true), opt, failures, session)
         record.annotation_summary = annotation_summary
         U.remove_tree(cache.root)
         return record
@@ -828,7 +866,7 @@ function Downloader:book(input, opt, progress)
     progress("package", #chapters, expected, book.title)
     opt.expected_chapter_count = expected
     opt.checkpointed = false
-    local record = self:_save(book, chapters, assets, table.concat(css_list, "\n"), self:_cover(book, true), opt, failures, session)
+    local record = self:_save(book, chapters, assets, final_css(css_list, css_seen), self:_cover(book, true), opt, failures, session)
     record.annotation_summary = annotation_summary
     return record
 end
@@ -838,5 +876,7 @@ Downloader._namespace_assets = namespace_assets
 Downloader._catalog_signature = catalog_signature
 Downloader._option_key = option_key
 Downloader._validate_epub = validate_epub
+Downloader._reader_control_css = READER_CONTROL_CSS
+Downloader._final_css = final_css
 
 return Downloader

--- a/miuread.koplugin/miuread/thought_popup.lua
+++ b/miuread.koplugin/miuread/thought_popup.lua
@@ -14,7 +14,7 @@ local VerticalSpan = require("ui/widget/verticalspan")
 local Screen = Device.screen
 
 local function screen_ratios()
-    return 0.91, 0.60
+    return 0.92, 0.68
 end
 
 local function safe_margins()
@@ -57,8 +57,8 @@ function Popup:init()
 
     local screen_w, screen_h = Screen:getWidth(), Screen:getHeight()
     local auto_w, auto_h = screen_ratios()
-    local width_ratio = math.max(0.86, math.min(0.92, tonumber(self.width_ratio) or auto_w))
-    local height_ratio = math.max(0.48, math.min(0.64, tonumber(self.height_ratio) or auto_h))
+    local width_ratio = math.max(0.88, math.min(0.95, tonumber(self.width_ratio) or auto_w))
+    local height_ratio = math.max(0.54, math.min(0.72, tonumber(self.height_ratio) or auto_h))
     local side_margin, vertical_margin = safe_margins()
 
     self.width = math.min(math.floor(screen_w * width_ratio), screen_w - side_margin * 2)
@@ -141,10 +141,10 @@ function Popup:_source_height(width, max_height)
         or tonumber(metrics.source_chars)
         or 1
 
-    -- The source text is rendered at .68em. Account for the HTML body and
+    -- The source text is rendered at .88em. Account for the HTML body and
     -- source-box horizontal padding, then estimate the actual wrapped lines.
-    local source_font = math.max(1, self.font_size * 0.68)
-    local horizontal_padding = self.font_size * (0.52 + 0.46) + Screen:scaleBySize(4)
+    local source_font = math.max(1, self.font_size * 0.88)
+    local horizontal_padding = self.font_size * (0.52 + 1.16) + Screen:scaleBySize(6)
     local usable_width = math.max(source_font * 6, width - horizontal_padding)
     local units_per_line = math.max(6, usable_width / source_font)
     local lines = math.max(1, math.min(3, math.ceil(source_units / units_per_line - 0.001)))
@@ -153,9 +153,9 @@ function Popup:_source_height(width, max_height)
     -- padding/border and the real number of source lines. A small safety pad
     -- avoids clipping from font rounding without leaving a blank viewport.
     local body_padding = self.font_size * (0.18 + 0.20)
-    local heading_height = self.font_size * (0.52 * 1.02 + 0.16)
-    local source_lines = lines * self.font_size * 0.68 * 1.15
-    local box_padding = self.font_size * (0.17 * 2) + 2
+    local heading_height = self.font_size * (0.82 * 1.10 + 0.32 + 0.26)
+    local source_lines = lines * self.font_size * 0.88 * 1.42
+    local box_padding = self.font_size * (0.40 * 2) + 3
     local safety = math.max(2, Screen:scaleBySize(3))
     local estimated = math.ceil(body_padding + heading_height + source_lines + box_padding + safety)
 
@@ -167,8 +167,8 @@ function Popup:_build()
 
     local screen_w, screen_h = Screen:getWidth(), Screen:getHeight()
     local border = math.max(1, tonumber(Size.border.window) or 1)
-    local padding = math.max(4, Screen:scaleBySize(4))
-    local close_size = math.max(Screen:scaleBySize(18), math.floor(self.font_size * 0.62))
+    local padding = math.max(7, Screen:scaleBySize(7))
+    local close_size = math.max(Screen:scaleBySize(24), math.floor(self.font_size * 0.82))
     local close_inset = math.max(4, Screen:scaleBySize(5))
     local inner_w = self.width - padding * 2 - border * 2
     local max_inner_h = self.max_height - padding * 2 - border * 2
@@ -244,7 +244,7 @@ function Popup:_build()
         padding = 0,
         bordersize = 0,
         text_font_face = "cfont",
-        text_font_size = math.max(13, math.floor(self.font_size * 0.50)),
+        text_font_size = math.max(16, math.floor(self.font_size * 0.62)),
         text_font_bold = true,
         show_parent = self,
         callback = function() self:_request_close() end,

--- a/miuread.koplugin/miuread/thoughts.lua
+++ b/miuread.koplugin/miuread/thoughts.lua
@@ -248,7 +248,8 @@ local function panel_head_html(title)
 end
 
 local function source_box_html(text)
-    return '<div class="miu-source"><div class="miu-source-box">' .. U.xml(text or "") .. '</div></div>'
+    return '<div class="miu-source"><div class="miu-source-box"><span class="miu-quote">&#8220;</span>'
+        .. U.xml(text or "") .. '<span class="miu-quote">&#8221;</span></div></div>'
 end
 
 local function entry_html(item)
@@ -302,17 +303,15 @@ function Thoughts.popup_parts(group)
         return "", "", {source_chars=0, source_units=0, comment_count=0, comment_chars={}}
     end
 
-    local fixed, body = {}, {}
+    local fixed, comments = {}, {}
     local metrics = {source_chars=0, source_units=0, comment_count=0, comment_chars={}}
     local abstract = Thoughts.group_abstract(group)
     if abstract ~= "" then
         local source = preview(abstract, 72)
         metrics.source_chars = codepoint_len(source)
         metrics.source_units = display_units(source)
-        fixed[#fixed + 1] = panel_head_html("正文")
+        fixed[#fixed + 1] = panel_head_html("原文")
         fixed[#fixed + 1] = source_box_html(source)
-    else
-        body[#body + 1] = panel_head_html("评论")
     end
 
     local seen = {}
@@ -327,13 +326,18 @@ function Thoughts.popup_parts(group)
                 seen[key] = true
                 metrics.comment_count = metrics.comment_count + 1
                 metrics.comment_chars[#metrics.comment_chars + 1] = codepoint_len(content)
-                body[#body + 1] = entry_html{
+                comments[#comments + 1] = entry_html{
                     author = author,
                     content = content,
                     likes = tonumber(item.likes or 0) or 0,
                 }
             end
         end
+    end
+    local body = {}
+    if metrics.comment_count > 0 then
+        body[1] = panel_head_html("想法 · " .. tostring(metrics.comment_count))
+        for _, html in ipairs(comments) do body[#body + 1] = html end
     end
     return table.concat(fixed), table.concat(body), metrics
 end
@@ -343,20 +347,30 @@ function Thoughts.full_html(group)
     return fixed .. body, metrics
 end
 
-function Thoughts.popup_css()
-    return [[
+local function css_font_family(value)
+    local face = clean(value)
+    if face == "" then return "serif" end
+    face = face:gsub("\\", "\\\\"):gsub('"', '\\"')
+    return '"' .. face .. '", serif'
+end
+
+function Thoughts.popup_css(font_face, font_definitions)
+    return tostring(font_definitions or "") .. [[
 @page{margin:0}
 html{margin:0!important;padding:0!important}
-body{margin:0!important;padding:.18em .26em .20em .26em!important;font-family:sans-serif;line-height:1.18;color:#000;background:#fff}
-.miu-panel-head{font-size:.52em;font-weight:normal;line-height:1.02;color:#555;margin:0 1.9em .16em 0;padding:0}
+body{margin:0!important;padding:.18em .26em .20em .26em!important;font-family:]]
+        .. css_font_family(font_face)
+        .. [[;line-height:1.18;color:#000;background:#fff}
+.miu-panel-head{font-size:.82em;font-weight:bold;line-height:1.10;color:#111;margin:0 2.4em .32em 0;padding:0 0 .26em 0;border-bottom:2px solid #222}
 .miu-source{margin:0;padding:0}
-.miu-source-box{font-size:.68em;line-height:1.15;color:#444;margin:0;padding:.17em .23em;border:1px solid #aaa}
-.miu-comment{margin:0;padding:.14em 0 .13em 0;border:0;page-break-inside:avoid;break-inside:avoid-page}
-.miu-comment+.miu-comment{margin-top:.13em;padding-top:.18em;border-top:1px solid #c8c8c8}
-.miu-meta{margin:0;padding:0;line-height:1.02;page-break-after:avoid}
-.miu-author{font-size:.49em;font-weight:normal;color:#666;line-height:1.02}
-.miu-likes{font-size:.47em;font-weight:normal;color:#777;line-height:1.02;white-space:nowrap}
-.miu-content{font-size:.80em;line-height:1.20;margin:.07em 0 0 0;padding:0 0 .08em 0;page-break-before:avoid;orphans:2;widows:2}
+.miu-source-box{font-size:.88em;line-height:1.42;color:#333;margin:0;padding:.40em .58em;background:#eee;border-left:3px solid #333}
+.miu-quote{font-weight:bold;color:#555}
+.miu-comment{margin:0;padding:.42em .08em .48em .08em;border:0;page-break-inside:avoid;break-inside:avoid-page}
+.miu-comment+.miu-comment{padding-top:.52em;border-top:1px solid #aaa}
+.miu-meta{margin:0;padding:0;line-height:1.12;page-break-after:avoid}
+.miu-author{font-size:.72em;font-weight:bold;color:#333;line-height:1.12}
+.miu-likes{font-size:.66em;font-weight:normal;color:#666;line-height:1.12;white-space:nowrap}
+.miu-content{font-size:1em;line-height:1.48;margin:.22em 0 0 0;padding:0;page-break-before:avoid;orphans:2;widows:2}
 ]]
 end
 return Thoughts


### PR DESCRIPTION
## 背景

觅阅导出的不同微信读书 EPUB 会携带不同的出版社 CSS。普通书籍可能在每章返回略有差异的完整样式表，打包时这些样式会被拼接；公众号/轻排版内容的样式则简单得多。因此，同样由觅阅生成的书可能出现以下差异：

- 出版社指定的字体、行高、页边距覆盖 KOReader 的阅读设置；
- 多份旧划线规则被拼接，后出现的实线规则覆盖想要的虚线规则；
- 想法链接还可能叠加 KOReader 的默认链接下划线，形成“实线 + 虚线”；
- 想法弹窗固定使用无衬线字体，和正文当前字体不一致，信息层级也比较拥挤。

## 修改内容

### 1. 让 KOReader 接管正文排版

- 移除生成 EPUB 时固定的 `line-height: 1.75` 和 `5%` body 外边距；
- 在所有章节/出版社样式收集完成后追加 reader-control CSS；
- 正文、标题和常用块级/行内元素继承 KOReader 当前字体；
- 将字距、词距和行高恢复为由阅读引擎控制的值；
- 保留出版社的结构性样式，例如标题字号、缩进、对齐、图片、分页和代码字体；
- 两条下载路径（断点缓存重建和普通打包）统一使用相同的最终 CSS 处理。

### 2. 普通划线和想法划线统一为虚线

- 普通微信读书划线与带想法划线统一使用 `2px dashed #555`；
- 明确关闭想法链接自身的默认下划线和边框，避免实线、虚线重叠；
- 在生成的划线/链接标签上加入确定性的内联样式，避免出版社 CSS 和 CRengine 级联差异改变线型；
- 最终打包前统一清除旧的 repair/V2/V3/临时虚线规则，只在样式表末尾保留一份 V4 规则；
- `css_is_current()` 现在通过重写幂等性判断样式是否真正干净，不会因为仅存在版本标记而误判；
- 旧 EPUB 的“修复划线样式”流程仍可迁移到新的 V4 样式。

### 3. 优化想法弹窗

- 将内容明确分成“原文”和“想法 · 数量”两个区域；
- 原文改为带引号和左侧强调线的引用卡片；
- 增大作者、点赞数和想法正文的字号与行距；
- 增大弹窗可用宽高、内边距、关闭按钮和原文区域高度，减少拥挤与裁切；
- 保留评论去重、HTML 转义、分页保护和长内容滚动行为。

### 4. 弹窗字体跟随当前阅读字体

- 优先读取当前 ReaderUI 的字体，其次读取文档字体和全局 `cre_font`；
- 通过 crengine 获取当前字体常规、斜体、粗体、粗斜体的真实文件路径；
- 使用 `@font-face` 将字体文件提供给想法弹窗，支持 KOReader 自定义字体；
- 字体解析失败时安全回退到当前字体名称或 `serif`。

## 用户影响

- 不同来源、不同出版社样式的觅阅 EPUB 会有更一致的 KOReader 阅读体验；
- 字体、字号、行距及 CJK 字符间距相关设置不再被书内字体声明锁死；
- 所有微信读书划线保持同一种虚线外观，带想法的文本仍可点击；
- 想法弹窗更易读，并与当前正文使用同一字体。

## 提交范围

- 仅修改 `miuread.koplugin` 内 6 个 Lua 源文件；
- 不包含任何单本书的 EPUB、出版社 CSS、书籍元数据或阅读缓存；
- 不包含本地测试书、备份文件、设备配置或临时测试脚本；
- 划线内联样式由插件统一生成并应用于所有下载内容，不包含书籍 ID、书名或单书选择器。

## 通用测试

- 使用 `luaparse` 检查 6 个改动 Lua 文件，全部通过；
- 使用 Fengari/Lua 断言覆盖：
  - repair、V2、V3 和重复划线规则迁移到单一 V4 规则；
  - CSS 重写的幂等性以及 `css_is_current()` 判定；
  - 普通划线与想法划线 HTML 生成、链接 href、内联虚线样式及统计数据；
  - 想法弹窗的原文/想法分区、重复评论过滤、HTML 转义和计数；
  - 字体名称转义、注入 `@font-face` 以及 fallback CSS；
  - reader-control CSS 位于出版社样式之后，V4 划线规则位于最终样式末尾；
- 验证 EPUB 打包后的样式只包含一个 V4 划线块，旧版规则已清理；
- 验证生成的想法链接仍保留可点击 href，普通划线与想法划线使用同一通用样式；
- `git diff --check` 通过。

## 兼容性说明

- 没有修改认证、同步、书架或阅读进度协议；
- 没有移除标题、缩进、对齐、图片和分页等出版社结构样式；
- 旧版划线样式标记会由现有 EPUB 样式修复流程升级，无需重新下载整本书。
