### PR TITLE
fix(android): Android系统12+下载子进程被系统杀死导致下载中断

### DIFF
--- a/miuread.koplugin/miuread/download_task.lua
+++ b/miuread.koplugin/miuread/download_task.lua
@@ -33,6 +33,61 @@ local function serializable_copy(value, seen)
     return out
 end
 
+-- Android 12 起，系统会监控并杀死应用 fork() 出来的“幻影进程”（phantom
+-- process）。被 SIGKILL 杀掉的子进程不会留下任何 Lua 错误或崩溃日志，表现
+-- 就是下载跑几章后突然中断。更致命的是 EPUB 打包阶段无法断点续传，子进程
+-- 根本活不到打包结束，因此在 Android 上必须放弃 fork，改为主进程内协程分片。
+local function fork_is_reliable()
+    local ok, is_android = pcall(function() return Device:isAndroid() end)
+    if ok and is_android == true then return false end
+    return true
+end
+
+-- 进度状态构造：fork 模式与前台协程模式共用，保证两条路径产出的字段完全一致
+local function progress_state(stage, current, total, chapter, detail)
+    detail = detail or {}
+    local percent
+    if stage == "package" then
+        percent = 0.96
+    elseif total and total > 0 then
+        local base = (math.max(1, current) - 1) / total
+        local step = 0
+        if stage == "resume" then step = 0.90
+        elseif stage == "content" then step = 0.08
+        elseif stage == "underlines" then step = 0.35
+        elseif stage == "thoughts" then step = 0.55
+        elseif stage == "footnotes" then step = 0.75
+        elseif stage == "images" then step = 0.88 end
+        percent = math.min(0.94, base * 0.94 + step / total)
+    end
+    if stage == "package" then
+        detail.message = detail.message or "正在低内存生成并验证 EPUB"
+    end
+    return {
+        stage = stage,
+        current = current,
+        total = total,
+        chapter = chapter,
+        batch = detail.batch,
+        batch_total = detail.batches,
+        underlines = detail.underlines,
+        thoughts = detail.thoughts,
+        percent = percent,
+        message = detail.message,
+    }
+end
+
+-- 文件路径与行号在日志里有用，但在下载对话框里只会让人困惑，只保留原因
+local function friendly_error(raw)
+    local raw_error = tostring(raw)
+    local display = raw_error:match("^(.-)\nstack traceback:") or raw_error
+    display = display:gsub("^.-%.lua:%d+:%s*", "")
+    if raw_error:lower():find("not enough memory", 1, true) then
+        display = "设备内存不足，未生成新的 EPUB。原有完整书未被覆盖，已完成章节仍保存在断点缓存；再次下载时会继续。"
+    end
+    return display
+end
+
 function DownloadTask:new(store)
     return setmetatable({
         store = store,
@@ -46,6 +101,15 @@ function DownloadTask:new(store)
         owner_path = store.temp_dir .. "/download-task-owner.json",
         owner_token = tostring(os.time()) .. "-" .. tostring(math.random(100000,999999)),
     }, self)
+end
+
+-- 是否使用前台协程模式。用户可在偏好里用 download_inline 强制开或强制关。
+function DownloadTask:_use_inline()
+    local ok, prefs = pcall(function() return self.store:preferences() end)
+    prefs = (ok and type(prefs) == "table") and prefs or {}
+    if prefs.download_inline == true then return true end
+    if prefs.download_inline == false then return false end
+    return not fork_is_reliable()
 end
 
 function DownloadTask:set_backgrounded(value)
@@ -99,6 +163,8 @@ end
 function DownloadTask:descriptor()
     local job=self.job
     if not job then return nil end
+    -- 前台协程任务不存在跨进程句柄，无法被其他实例接管
+    if job.inline then return nil end
     return {
         pid=job.pid,progress_path=job.progress_path,result_path=job.result_path,
         cancel_path=job.cancel_path,worker_settings_path=job.worker_settings_path,
@@ -137,6 +203,7 @@ function DownloadTask:_release_awake()
 end
 
 function DownloadTask:available()
+    if self:_use_inline() then return true end
     return type(FFIUtil.runInSubProcess) == "function"
         and type(FFIUtil.isSubProcessDone) == "function"
 end
@@ -204,12 +271,14 @@ function DownloadTask:_finish(job, forced_error)
     if self:_owns_job() then os.remove(self.owner_path) end
     self.job = nil
     self:_release_awake()
+    pcall(function() require("miuread.ratelimit").release() end)
     if job.on_done then job.on_done(result) end
 end
 
 function DownloadTask:_poll()
     local job = self.job
     if not job then return end
+    if job.inline then return end
     if not self:_owns_job() then
         logger.info("[MiuRead][DownloadTask] controller ownership transferred","pid=",tostring(job.pid))
         self.job=nil
@@ -273,13 +342,19 @@ end
 
 function DownloadTask:cancel()
     local job = self.job
-    if not job or job.cancel_requested_at or not self:_owns_job() then return end
+    if not job or job.cancel_requested_at then return end
+    if job.inline then
+        job.cancel_requested_at = os.time()
+        return
+    end
+    if not self:_owns_job() then return end
     job.cancel_requested_at = os.time()
     U.atomic_write(job.cancel_path, "1", true)
 end
 
 function DownloadTask:attach(descriptor,on_progress,on_done)
     if self.job then return false,"已有下载任务正在运行" end
+    if self:_use_inline() then return false,"当前平台使用前台下载，无后台任务可接管" end
     if not self:available() then return false,"当前 KOReader 不支持下载子进程" end
     descriptor=type(descriptor)=="table" and descriptor or nil
     local pid=descriptor and tonumber(descriptor.pid)
@@ -321,8 +396,143 @@ function DownloadTask:attach(descriptor,on_progress,on_done)
     return true
 end
 
+-- =====================================================================
+-- 前台协程模式：不 fork，在主进程内分片执行，规避 Android 幻影进程杀手
+-- =====================================================================
+function DownloadTask:_start_inline(book, options, on_progress, on_done)
+    local Http = require("miuread.http")
+    local Api = require("miuread.api")
+    local Reader = require("miuread.reader")
+    local Annotations = require("miuread.annotations")
+    local Downloader = require("miuread.downloader")
+
+    self.keep_awake_enabled = self.store:preferences().download_keep_awake ~= false
+
+    local store = self.store
+    local job = {
+        inline = true,
+        started_at = os.time(),
+        last_keepalive = 0,
+        last_progress_state = nil,
+        last_progress_at = nil,
+        cancel_requested_at = nil,
+        on_progress = on_progress,
+        on_done = on_done,
+    }
+    self.job = job
+
+    local http = Http:new(store)
+    local reader = Reader:new(http, store)
+    local api = Api:new(http, store, reader)
+    local annotations = Annotations:new(api)
+    local downloader = Downloader:new(reader, api, annotations, store, http)
+
+    -- 浅拷贝，避免把 cancelled 回调写回调用方的表里
+    local opts = {}
+    for k, v in pairs(options or {}) do opts[k] = v end
+    opts.cancelled = function() return job.cancel_requested_at ~= nil end
+
+    local function report(state)
+        state = state or {}
+        state.updated_at = os.time()
+        job.last_progress_state = state
+        job.last_progress_at = state.updated_at
+        if job.on_progress then pcall(job.on_progress, state) end
+    end
+
+    pcall(function()
+        require("miuread.ratelimit").configure{
+            cooperative = true,
+            interrupt = function() return job.cancel_requested_at ~= nil end,
+            notifier = function(remaining, attempt, total)
+                local snapshot = U.copy(job.last_progress_state or {}) or {}
+                snapshot.message = string.format(
+                    "接口访问过于频繁，%d 秒后自动重试（%d/%d）",
+                    math.floor(tonumber(remaining) or 0),
+                    tonumber(attempt) or 1, tonumber(total) or 1)
+                snapshot.updated_at = os.time()
+                if job.on_progress then pcall(job.on_progress, snapshot) end
+            end,
+        }
+    end)
+
+    local function finish(result)
+        if self.job ~= job then return end
+        self.job = nil
+        self:_release_awake()
+        pcall(function() require("miuread.ratelimit").release() end)
+        if job.on_done then job.on_done(result) end
+    end
+
+    local co = coroutine.create(function()
+        local ok, value = xpcall(function()
+            return downloader:book(book, opts, function(stage, current, total, chapter, detail)
+                report(progress_state(stage, current, total, chapter, detail))
+                -- 交还控制权，让界面重绘并处理“取消”点击。
+                -- LuaJIT 允许跨 pcall 让出；万一底层不支持，pcall 兜住后退化为
+                -- 纯阻塞执行，结果依然正确，只是界面在下载期间不响应。
+                pcall(coroutine.yield)
+            end)
+        end, debug.traceback)
+        return ok, value
+    end)
+
+    local pump
+    pump = function()
+        if self.job ~= job then return end
+        local now = os.time()
+        if not job.last_keepalive or now - job.last_keepalive >= 5 then
+            job.last_keepalive = now
+            self:_reset_device_timeout()
+        end
+
+        local resumed, ok, value = coroutine.resume(co)
+        if self.job ~= job then return end
+
+        if not resumed then
+            -- 协程自身出错（例如无法跨边界让出），ok 里是错误信息
+            local message = friendly_error(ok)
+            report{stage = "error", message = message}
+            finish{ok = false, error = message}
+            return
+        end
+
+        if coroutine.status(co) == "dead" then
+            if ok then
+                report{stage = "done", current = 1, total = 1, percent = 1,
+                       chapter = book.title or ""}
+                finish{
+                    ok = true,
+                    value = serializable_copy(value),
+                    auth = serializable_copy(store:auth()),
+                    session = serializable_copy(store:session(book.bookId)),
+                }
+            else
+                local message = friendly_error(value)
+                logger.warn("[MiuRead][DownloadTask] inline failed", tostring(value))
+                report{stage = job.cancel_requested_at and "cancelled" or "error",
+                       message = message}
+                finish{ok = false, error = message}
+            end
+            return
+        end
+
+        UIManager:scheduleIn(0.01, pump)
+    end
+
+    report(progress_state("prepare", 0, 1, book.title or "", nil))
+    self.backgrounded = false
+    self:_hold_awake()
+    logger.info("[MiuRead][DownloadTask] started inline (fork disabled on this platform)")
+    UIManager:scheduleIn(0, pump)
+    return true
+end
+
 function DownloadTask:start(book, options, on_progress, on_done)
     if self.job then return false, "已有下载任务正在运行" end
+    if self:_use_inline() then
+        return self:_start_inline(book, options, on_progress, on_done)
+    end
     if not self:available() then return false, "当前 KOReader 不支持下载子进程" end
 
     local stamp = tostring(os.time()) .. "-" .. tostring(math.random(10000, 99999))
@@ -352,13 +562,36 @@ function DownloadTask:start(book, options, on_progress, on_done)
         local UChild = require("miuread.util")
         local LoggerChild = require("logger")
 
-        local function emit(state)
+        local function write_progress(state)
             state = state or {}
             state.task_token = task_token
             state.updated_at = os.time()
             local ok, encoded = pcall(JsonChild.encode, state)
             if ok then UChild.atomic_write(progress_path, encoded, true) end
         end
+
+        local last_state = {}
+        local function emit(state)
+            state = state or {}
+            last_state = state
+            write_progress(state)
+        end
+
+        -- 限流退避期间每秒写一次进度，兼作心跳，避免父进程误判为“无响应”
+        pcall(function()
+            require("miuread.ratelimit").configure{
+                cooperative = false,
+                interrupt = function() return UChild.file_exists(cancel_path) end,
+                notifier = function(remaining, attempt, total)
+                    local snapshot = UChild.copy(last_state) or {}
+                    snapshot.message = string.format(
+                        "接口访问过于频繁，%d 秒后自动重试（%d/%d）",
+                        math.floor(tonumber(remaining) or 0),
+                        tonumber(attempt) or 1, tonumber(total) or 1)
+                    write_progress(snapshot)
+                end,
+            }
+        end)
 
         local ok, value = xpcall(function()
             local store = Store:new{
@@ -376,36 +609,7 @@ function DownloadTask:start(book, options, on_progress, on_done)
             end
             emit{stage = "prepare", current = 0, total = 1, chapter = clean_book.title or ""}
             local record = downloader:book(clean_book, clean_options, function(stage, current, total, chapter, detail)
-                detail = detail or {}
-                local percent
-                if stage == "package" then
-                    percent = 0.96
-                elseif total and total > 0 then
-                    local base = (math.max(1, current) - 1) / total
-                    local step = 0
-                    if stage == "resume" then step = 0.90
-                    elseif stage == "content" then step = 0.08
-                    elseif stage == "underlines" then step = 0.35
-                    elseif stage == "thoughts" then step = 0.55
-                    elseif stage == "footnotes" then step = 0.75
-                    elseif stage == "images" then step = 0.88 end
-                    percent = math.min(0.94, base * 0.94 + step / total)
-                end
-                if stage == "package" then
-                    detail.message = detail.message or "正在低内存生成并验证 EPUB"
-                end
-                emit{
-                    stage = stage,
-                    current = current,
-                    total = total,
-                    chapter = chapter,
-                    batch = detail.batch,
-                    batch_total = detail.batches,
-                    underlines = detail.underlines,
-                    thoughts = detail.thoughts,
-                    percent = percent,
-                    message = detail.message,
-                }
+                emit(progress_state(stage, current, total, chapter, detail))
             end)
             return {
                 record = record,
@@ -426,18 +630,19 @@ function DownloadTask:start(book, options, on_progress, on_done)
         else
             local raw_error = tostring(value)
             LoggerChild.warn("[MiuRead][DownloadTask] child failed", raw_error)
-            local display_error = raw_error:match("^(.-)\nstack traceback:") or raw_error
-            -- File paths and line numbers are useful in logs but confusing in
-            -- the download dialog. Keep the actual reason only.
-            display_error = display_error:gsub("^.-%.lua:%d+:%s*", "")
-            if raw_error:lower():find("not enough memory", 1, true) then
-                display_error = "设备内存不足，未生成新的 EPUB。原有完整书未被覆盖，已完成章节仍保存在断点缓存；再次下载时会继续。"
-            end
+            local display_error = friendly_error(raw_error)
             emit{stage = UChild.file_exists(cancel_path) and "cancelled" or "error", message = display_error}
             payload = {ok = false, error = display_error}
         end
-        local encoded = JsonChild.encode(payload)
-        UChild.atomic_write(result_path, encoded, true)
+        -- 结果写入必须绝对不能抛错，否则子进程会静默死亡、父进程只能报“异常退出”
+        local encoded_ok, encoded = pcall(JsonChild.encode, payload)
+        if not encoded_ok then
+            encoded_ok, encoded = pcall(JsonChild.encode,
+                {ok = false, error = "下载结果无法序列化：" .. tostring(encoded)})
+        end
+        if encoded_ok then
+            pcall(UChild.atomic_write, result_path, encoded, true)
+        end
     end
 
     local ok, pid, err = pcall(FFIUtil.runInSubProcess, child, false, false)

--- a/miuread.koplugin/miuread/http.lua
+++ b/miuread.koplugin/miuread/http.lua
@@ -269,5 +269,5 @@ end
 Http.auth_error_code = auth_error_code
 Http.auth_error_message = auth_error_message
 Http.is_auth_error = is_auth_error
-
+pcall(function() require("miuread.ratelimit").install(Http) end)
 return Http

--- a/miuread.koplugin/miuread/ratelimit.lua
+++ b/miuread.koplugin/miuread/ratelimit.lua
@@ -1,0 +1,238 @@
+--[[
+MiuRead 限流补丁模块
+路径：koreader/plugins/miuread.koplugin/miuread/ratelimit.lua
+
+作用：
+  1) 请求节流——保证两次请求之间有最小间隔，避免快设备瞬间打爆配额
+  2) 限流退避——识别 "Hit api rate limit" 类错误体，指数等待后重试
+  3) 协作模式——前台协程下载时，等待期间让出控制权，界面不会卡死
+  4) 可取消——长等待切片执行，"取消下载" 仍能及时生效
+
+慢设备（Kindle/Kobo）单次请求耗时本就超过最小间隔，行为完全不变。
+]]
+
+local logger = require("logger")
+local ok_socket, socket = pcall(require, "socket")
+local unpack = table.unpack or unpack
+
+local RateLimit = {}
+
+-- ======================= 可调参数 =======================
+RateLimit.base_interval = 0.30   -- 基准最小请求间隔（秒）
+RateLimit.min_interval  = 0.30   -- 当前生效间隔，会自适应变化
+RateLimit.max_interval  = 2.50   -- 自适应上限
+RateLimit.backoff       = {4, 8, 15, 25, 40}  -- 撞限流后的等待序列（秒）
+RateLimit.blocking      = false  -- 允许退避重试（子进程/前台任务均置 true）
+RateLimit.cooperative   = false  -- 前台协程模式：等待期间让出控制权
+RateLimit.notifier      = nil    -- function(remaining_seconds, attempt, total)
+RateLimit.interrupt     = nil    -- function() -> true 表示已取消
+-- =======================================================
+
+local last_start = 0
+local success_streak = 0
+
+local function pack(...)
+    return {n = select("#", ...), ...}
+end
+
+local function monotonic()
+    if ok_socket and socket and type(socket.gettime) == "function" then
+        return socket.gettime()
+    end
+    return os.time()
+end
+
+local function sleep(seconds)
+    seconds = tonumber(seconds) or 0
+    if seconds <= 0 then return end
+    if ok_socket and socket and type(socket.sleep) == "function" then
+        socket.sleep(seconds)
+    end
+end
+
+--- 判断一个错误是否属于"接口频率限制"
+function RateLimit.is_rate_limit(message)
+    local text = tostring(message or "")
+    local lower = text:lower()
+    return lower:find("rate limit", 1, true) ~= nil
+        or lower:find("ratelimit", 1, true) ~= nil
+        or lower:find("too many request", 1, true) ~= nil
+        or lower:find("http 429", 1, true) ~= nil
+        or lower:find("http 503", 1, true) ~= nil
+        or text:find("频率", 1, true) ~= nil
+        or text:find("过于频繁", 1, true) ~= nil
+        or text:find("请求过快", 1, true) ~= nil
+end
+
+local function interrupted()
+    if type(RateLimit.interrupt) ~= "function" then return false end
+    local ok, stop = pcall(RateLimit.interrupt)
+    return ok and stop == true
+end
+
+local function notify(remaining, attempt, total)
+    if type(RateLimit.notifier) ~= "function" then return end
+    pcall(RateLimit.notifier, remaining, attempt, total)
+end
+
+-- 只限制"最快速度"：上一次请求本身耗时已超过间隔时，这里完全不等待
+local function throttle()
+    local interval = tonumber(RateLimit.min_interval) or 0
+    if interval <= 0 then
+        last_start = monotonic()
+        return
+    end
+    local wait = (last_start + interval) - monotonic()
+    if wait > interval then wait = interval end   -- 防时钟跳变
+    if wait > 0 then sleep(wait) end
+    last_start = monotonic()
+end
+
+local function escalate(reason)
+    success_streak = 0
+    local current = tonumber(RateLimit.min_interval) or RateLimit.base_interval
+    local raised = math.min(RateLimit.max_interval, current * 1.6 + 0.10)
+    if raised > current then
+        RateLimit.min_interval = raised
+        logger.warn("[MiuRead][RateLimit] 放慢请求间隔 ->",
+            string.format("%.2f", raised), "原因=", tostring(reason))
+    end
+end
+
+local function relax()
+    success_streak = success_streak + 1
+    if success_streak < 25 then return end
+    success_streak = 0
+    local current = tonumber(RateLimit.min_interval) or RateLimit.base_interval
+    if current > RateLimit.base_interval then
+        RateLimit.min_interval = math.max(RateLimit.base_interval, current * 0.8)
+    end
+end
+
+-- 长等待切片执行：
+--   * 每秒检查一次取消
+--   * 每秒回报一次剩余时间（子进程模式下同时充当心跳，避免父进程误判为死亡）
+--   * 协作模式下让出协程，前台界面不会假死
+local function long_sleep(seconds, attempt, total)
+    local remaining = tonumber(seconds) or 0
+    while remaining > 0 do
+        if interrupted() then error("下载已取消", 0) end
+        local slice = remaining > 1 and 1 or remaining
+        sleep(slice)
+        remaining = remaining - slice
+        notify(remaining, attempt, total)
+        if RateLimit.cooperative then
+            -- 不在协程里时 coroutine.yield 会报错，用 pcall 兜住即可
+            pcall(coroutine.yield)
+        end
+    end
+    if interrupted() then error("下载已取消", 0) end
+end
+
+local function retry_count(opt)
+    local explicit = tonumber(opt and opt.rate_limit_retries)
+    if explicit then return explicit end
+    if RateLimit.blocking then return #(RateLimit.backoff or {}) end
+    return 0
+end
+
+-- 保留 "rate limit" 字样，便于上层继续识别
+local function limit_error(original)
+    error("接口访问频率超限（微信读书 rate limit）。已完成章节均已保存为断点，"
+        .. "请等待约 10 分钟后再点“继续下载”。\n原始错误："
+        .. tostring(original), 0)
+end
+
+local function with_retry(opt, fn)
+    local total = retry_count(opt)
+    local backoff = RateLimit.backoff or {}
+    for attempt = 0, total do
+        local r = pack(pcall(fn))
+        if r[1] then
+            relax()
+            return unpack(r, 2, r.n)
+        end
+        local err = r[2]
+        -- 非限流错误原样抛出，行为与打补丁前完全一致
+        if not RateLimit.is_rate_limit(err) then error(err, 0) end
+        escalate(err)
+        if attempt >= total then limit_error(err) end
+        local wait = tonumber(backoff[attempt + 1])
+            or tonumber(backoff[#backoff]) or 30
+        logger.warn("[MiuRead][RateLimit] 命中限流，等待", tostring(wait),
+            "秒后重试 attempt=", tostring(attempt + 1))
+        notify(wait, attempt + 1, total)
+        long_sleep(wait, attempt + 1, total)
+    end
+end
+
+--- 安装到 http 模块，幂等
+function RateLimit.install(Http)
+    if type(Http) ~= "table" then return false end
+    if Http.__miuread_ratelimit then return true end
+    Http.__miuread_ratelimit = true
+
+    local original_request = Http.request
+    if type(original_request) == "function" then
+        Http.request = function(self, opt, ...)
+            throttle()
+            local r = pack(original_request(self, opt, ...))
+            local code = tonumber(r[2])
+            if code == 429 or code == 503 then
+                escalate("HTTP " .. tostring(code))
+            end
+            return unpack(r, 1, r.n)
+        end
+    end
+
+    local original_json = Http.json
+    if type(original_json) == "function" then
+        Http.json = function(self, opt, ...)
+            local extra = pack(...)
+            return with_retry(opt, function()
+                return original_json(self, opt, unpack(extra, 1, extra.n))
+            end)
+        end
+    end
+
+    local original_download = Http.download
+    if type(original_download) == "function" then
+        Http.download = function(self, url, opt, ...)
+            local extra = pack(...)
+            return with_retry(opt, function()
+                return original_download(self, url, opt, unpack(extra, 1, extra.n))
+            end)
+        end
+    end
+
+    logger.info("[MiuRead][RateLimit] 已启用请求节流与限流退避",
+        "interval=", tostring(RateLimit.min_interval))
+    return true
+end
+
+--- 下载任务开始时调用
+function RateLimit.configure(config)
+    config = type(config) == "table" and config or {}
+    RateLimit.blocking = true
+    RateLimit.cooperative = config.cooperative == true
+    RateLimit.interrupt = config.interrupt
+    RateLimit.notifier = config.notifier
+    local interval = tonumber(config.min_interval)
+    if interval then
+        RateLimit.base_interval = interval
+        RateLimit.min_interval = math.max(interval, RateLimit.min_interval)
+    end
+end
+
+--- 下载任务结束时调用，恢复默认（避免影响书架浏览等前台请求）
+function RateLimit.release()
+    RateLimit.blocking = false
+    RateLimit.cooperative = false
+    RateLimit.interrupt = nil
+    RateLimit.notifier = nil
+end
+
+-- 兼容旧调用名
+RateLimit.configure_for_child = RateLimit.configure
+
+return RateLimit


### PR DESCRIPTION
喵老师好，我是小红书上反馈安卓下载中断的那个

## 问题
Android 13 上下载任何书都会中断，提示「下载子进程异常退出」，
而且 koreader 目录下没有任何 crash 文件，开调试模式也抓不到。
点「继续下载」能多下几章然后又断，因为永远活不到 package 阶段，
所以怎么点都拿不到成品书。

## 原因
Android 12 起有 phantom process killer，会 SIGKILL 应用 fork 出来、
不受 framework 管理的子进程。`runInSubProcess` 正好中招。
被 SIGKILL 不留 Lua 错误，所以没有 crash 日志。

这个限制在开发者选项里没有开关，只能 adb 关，普通用户搞不了，
所以只能在插件侧适配。

## 改动
**download_task.lua**
- 新增 `fork_is_reliable()`，`Device:isAndroid()` 为真时返回 false
- 新增 `_start_inline()`，用 coroutine 在主进程跑 `downloader:book()`，
  每次进度回调 yield 一次，UI 不卡死、取消按钮可响应
- `_use_inline()` 支持偏好项 `download_inline` 手动强制开/关
- `descriptor()` 在 inline 模式返回 nil，`cancel()`/`attach()`/`_poll()` 加 inline 分支
- 顺手修了个 bug：子进程结尾的 `Json.encode` + `atomic_write` 没有 pcall 保护，
  一旦抛错子进程会静默死亡且不写 result，父进程只能报「异常退出」，无从排查
- 把 `progress_state()` / `friendly_error()` 抽成公共函数给两条路径共用，
  逐行搬的应该等价，但这属于重构，需要重点review 一下

**ratelimit.lua（新增）+ http.lua（末尾一行挂载）**
下载时经常报 `Hit api rate limit` 后直接失败，加了节流和退避重试：
请求最小间隔 0.3s、命中限流后 4/8/15/25/40 秒退避、退避期间每秒回报剩余
时间兼作子进程心跳、支持取消。这部分**影响所有平台的请求节奏**，
如果风险大可以只取download_task.lua那部分，我另开 PR 也行

## 测试情况
- Android13 + KOReader（最新）：能完整下完并生成EPUB
- **Kindle / Kobo 没装koreader，没测过**。判断分支上其他平台走原fork路径，
  但ratelimit那部分是全平台生效的

## 已知限制
- inline 模式需要 KOReader 保持前台，不能退出koreader下载书籍，点击后台下载只能在koreader内一边看书一边下
- 安卓上失去了「重启后接管后台下载」的能力
- 更彻底的方案是 foreground service，但那是 KOReader 层面的事

代码是我用 AI 分析后生成的，我只能验证一下，需要review后再决定要不要合