### PR TITLE
fix: 转换脚注为 EPUB3 aside 后移除原脚注段落，避免章尾注释重复显示

### DIFF
--- a/miuread.koplugin/miuread/footnotes.lua
+++ b/miuread.koplugin/miuread/footnotes.lua
@@ -621,6 +621,51 @@ local function build_footnote_section(img_notes, anchor_notes)
     return table.concat(parts)
 end
 
+-- Some books (WeRead included) keep their original end-of-chapter footnote
+-- paragraphs (e.g. <p class="footnote" id="fn_ref_1">) next to the reference
+-- links. After convert_anchor_refs() rewrote those references to point at the
+-- EPUB3 <aside> footnotes we generate, leaving the original paragraphs behind
+-- would render every converted note a second time at the end of the chapter.
+-- Remove the source paragraphs whose anchor was actually converted, plus the
+-- footnote separator line that introduced them. Footnotes that were not
+-- resolved (and whose original links were deliberately preserved) are kept.
+local function strip_converted_footnote_sources(html, notes)
+    local converted = {}
+    for _, note in ipairs(notes or {}) do
+        local anchor = tostring(note and note.anchor or "")
+        if anchor ~= "" then converted[anchor] = true end
+    end
+    if not next(converted) then return html, 0 end
+
+    local removed = 0
+    -- Only footnote-ish container tags are considered, and only elements whose
+    -- id/name was converted are removed; any other element is left byte-for-byte
+    -- intact (the replacement callback returns nil so gsub keeps the match).
+    local tags = { "p", "li", "aside", "dd", "div" }
+    for _, tag in ipairs(tags) do
+        html = html:gsub("<" .. tag .. "(%s+[^>]*)>(.-)</" .. tag .. "%s*>", function(attrs, inner)
+            local cls = (get_attr(attrs, "class") or ""):lower()
+            if not (has_token(cls, "footnote") or has_token(cls, "endnote") or has_token(cls, "note")) then
+                return nil
+            end
+            local id = get_attr(attrs, "id") or get_attr(attrs, "name") or ""
+            if converted[id] then
+                removed = removed + 1
+                return ""
+            end
+            return nil
+        end)
+    end
+
+    if removed > 0 then
+        -- The generated <div class="footnotes"> section brings its own <hr/>,
+        -- so the original separator line(s) are no longer needed.
+        html = html:gsub('<[hH][rR][^>]*%sclass="[^"]*footnote%-separator[^"]*"[^>]*%s*/?>', "")
+            :gsub("<[hH][rR][^>]*%sclass='[^']*footnote%-separator[^']*'[^>]*%s*/?>", "")
+    end
+    return html, removed
+end
+
 function Footnotes.process(html, meta)
     local empty_stats={
         candidates=0,refs=0,converted=0,backlinks=0,image_notes=0,
@@ -686,6 +731,11 @@ function Footnotes.process(html, meta)
 
     local html1,img_notes=Footnotes.convert_img_footnotes(html)
     local html2,anchor_notes=convert_anchor_refs(html1,anchor_texts,#img_notes)
+    -- Remove the original publisher footnote paragraphs that were converted into
+    -- the EPUB3 <aside> footnotes above, so the same note is not rendered twice
+    -- at the end of the chapter. Unresolved notes keep their original markup.
+    local stripped_sources=0
+    html2,stripped_sources=strip_converted_footnote_sources(html2,anchor_notes)
 
     -- Some WeRead books omit the source-reference id while still emitting one
     -- reverse link for every note. The resulting signature is exact pairing:
@@ -705,7 +755,8 @@ function Footnotes.process(html, meta)
     local stats={
         candidates=#refs,
         refs=math.max(0,#refs-#backlinks),
-        converted=#anchor_notes,backlinks=#backlinks,inferred_backlinks=inferred_backlinks,image_notes=#img_notes,
+        converted=#anchor_notes,backlinks=#backlinks,inferred_backlinks=inferred_backlinks,
+        image_notes=#img_notes,stripped=stripped_sources,
         unresolved=#unresolved,deferred=#deferred,
         missing_anchors=unresolved,missing_targets=deferred,backlink_targets=backlinks,
         fallback=false,
@@ -713,7 +764,8 @@ function Footnotes.process(html, meta)
     log_info("candidates=",tostring(stats.candidates),"refs=",tostring(stats.refs),
         "converted=",tostring(stats.converted),"backlinks=",tostring(stats.backlinks),
         "inferred_backlinks=",tostring(stats.inferred_backlinks),
-        "images=",tostring(stats.image_notes),"missing=",tostring(stats.unresolved),
+        "images=",tostring(stats.image_notes),"stripped=",tostring(stats.stripped),
+        "missing=",tostring(stats.unresolved),
         "deferred=",tostring(stats.deferred))
     if stats.unresolved>0 then
         local sample={}


### PR DESCRIPTION
## 问题

微信读书等来源的章节内容里，脚注会同时存在两种形式：

- 旧式 `<p class="footnote" id="fn_ref_N">…</p>`（原始内容自带）
- 觅阅转换后生成的 EPUB3 `<aside class="footnote" id="wt_N">…</aside>`

`footnotes.lua` 把引用改写并追加 EPUB3 脚注段落后，**没有删除被转换的旧式脚注段落**，导致章尾同一注释显示两遍，且因 `p.footnote` 与 `aside.footnote` 的字体族声明不同，两遍呈现两种字体。

## 修改

在 `Footnotes.process()` 中，转换完成后新增 `strip_converted_footnote_sources()`：

- 按**已转换的锚点**（`note.anchor`）删除原脚注容器元素（`p/li/aside/dd/div`，带 footnote 相关 class 且 id/name 被转换）；
- 删除脚注分隔线 `<hr class="footnote-separator">`（生成的 `<div class="footnotes">` 自带分隔线）；
- **未解析**（保留原链接）的脚注不受影响；
- 非目标元素通过 `gsub` 回调返回 `nil` 原样保留，不做重建，避免误伤正文。

stats 增加 `stripped` 计数并写入日志，便于排查。

## 验证

- 本地 Lua 5.1 全插件语法检查通过（74 个文件）；
- 用模拟微信读书脚注结构的用例测试：已转换脚注被删除、未转换脚注保留、正文与生成段正常；
- 真机（Kindle + KOReader）重新生成书籍后，章尾脚注只显示一遍。