### PR TITLE
feat: 阅读快捷面板打开后再次下滑直接进入 KOReader 原生菜单

### DIFF
--- a/miuread.koplugin/main.lua
+++ b/miuread.koplugin/main.lua
@@ -7457,6 +7457,10 @@ function Plugin:show_reader_quick_panel()
         recent_buttons=self:_reader_recent_buttons(),
         footer_action={label="全部阅读功能  ›",callback=function() self:show_reader_control_center("reading") end},
         on_home=function() return self:return_to_miuread_home("reader surface") end,
+        on_swipe_down=function()
+            -- 首次下滑打开觅阅面板后，再次从顶部下滑直接进入 KOReader 原生菜单
+            return self:_show_koreader_reader_menu(function() self:show_reader_quick_panel() end)
+        end,
     }
     if not panel then
         logger.warn("[MiuRead][ReaderToolbar] unavailable",tostring(err or "unknown"))

--- a/miuread.koplugin/miuread/reader_toolbar.lua
+++ b/miuread.koplugin/miuread/reader_toolbar.lua
@@ -220,6 +220,7 @@ end
 function Toolbar:init()
     self.opts = self.opts or {}
     self.action_locked = false
+    self._swipe_armed = false -- 打开面板的同一次下滑仍会派发到面板，先禁用二次下滑
     local sw, sh = Screen:getWidth(), Screen:getHeight()
     local portrait = sw < sh
     local outer_margin = Skin.dp(10, 8, 18)
@@ -417,12 +418,32 @@ end
 
 function Toolbar:onSwipeDismiss(_, ges)
     if ges and ges.direction == "north" then return self:_close() end
+    if ges and ges.direction == "south" and self._swipe_armed == true
+        and type(self.opts.on_swipe_down) == "function" then
+        -- 觅阅面板已打开时再次从顶部下滑：交给原生 KOReader 菜单。
+        -- 限定在顶部条带内，避免占用面板下方区域的翻页下滑。
+        local start = ges.start_pos or ges.pos
+        local sh = Screen:getHeight()
+        local in_top = start and start.y >= 0 and start.y <= math.floor(sh * 0.12)
+        if in_top then
+            local ok, err = xpcall(self.opts.on_swipe_down, debug.traceback)
+            if not ok then logger.warn("[MiuRead][ReaderToolbar] on_swipe_down failed", tostring(err)) end
+            self:_close(nil, true)
+            return true
+        end
+    end
     return false
 end
 
 function Toolbar:onClose() return self:_close() end
 function Toolbar:onShow()
     UIManager:setDirty(self, function() return "ui", Skin.expand_region(self.panel_dimen) end)
+    -- 打开面板的那次下滑仍可能再次派发到本面板；短暂延迟后才启用
+    -- "再次下滑打开原生 KOReader 菜单"，避免首次下滑就同时打开两个菜单。
+    self._swipe_armed = false
+    UIManager:scheduleIn(.3, function()
+        if not self.closed then self._swipe_armed = true end
+    end)
 end
 function Toolbar:onCloseWidget()
     local region = self.panel_dimen and Skin.expand_region(self.panel_dimen) or nil


### PR DESCRIPTION
## 需求

当前阅读时从顶部下滑会打开觅阅快捷面板；想进入 KOReader 原生菜单需要再点「全部阅读功能 → 设备 → KOReader 高级菜单」，路径较长。

期望：**第一次下滑打开觅阅面板，面板稳定后再下滑一次直接进入 KOReader 原生菜单**。

## 修改

- `main.lua`：`show_reader_quick_panel()` 给 `ReaderToolbar.show()` 传入 `on_swipe_down` 回调，复用现有 `_show_koreader_reader_menu()`（与「KOReader 高级菜单」按钮同入口），原生菜单关闭后自动回到觅阅面板。
- `reader_toolbar.lua`：
  - `onSwipeDismiss` 处理**顶部条带内（屏幕高度 12% 以内）**的下滑，调用 `on_swipe_down`；面板下方区域的下滑仍走翻页，不误伤；
  - 增加 0.3s 武装延迟（`_swipe_armed`）：打开面板的那次下滑会被刚弹出的面板再次接收，延迟后才响应"再次下滑"，避免首次下滑就同时打开两个菜单。

## 验证

- 本地 Lua 5.1 全插件语法检查通过（74 个文件）；
- 真机（Kindle + KOReader）实测：
  - 第一次顶部下滑 → 仅觅阅快捷面板；
  - 第二次顶部下滑 → 直接进入 KOReader 原生菜单；
  - 关闭原生菜单 → 回到觅阅快捷面板；
  - 面板打开时屏幕下方下滑仍可翻页。