### PR TITLE
fix: 锁屏/主页优先使用觅阅高清封面，避免本地小图放大模糊

### DIFF
--- a/miuread.koplugin/main.lua
+++ b/miuread.koplugin/main.lua
@@ -8036,6 +8036,21 @@ function Plugin:_show_miuread_home_now(force_scan,from_refresh,quiet,refresh_kin
     local hero=self:_home_recent_book(miuread_rows,local_rows,account_rows)
     if hero then
         hero=U.copy(hero)
+        -- 优先使用觅阅缓存的封面（高清原图），避免本地元数据生成的小封面
+        -- （如 79x117 缩略图）在锁屏/主页放大显示时模糊。封面索引可能因
+        -- 后台下载/重建而缺失，此时直接按标准路径探测高清封面文件。
+        local hero_cached_cover=self.library:cached_cover_path(hero.bookId or hero.book_id)
+        if not hero_cached_cover and self.store and self.store.covers_dir then
+            local cover_id=U.id_name(hero.bookId or hero.book_id)
+            for _,cover_ext in ipairs({"jpg","png","gif","webp","svg"}) do
+                local cover_candidate=self.store.covers_dir.."/"..cover_id.."."..cover_ext
+                if self.library:_valid_cover_path(cover_candidate) then
+                    hero_cached_cover=cover_candidate
+                    break
+                end
+            end
+        end
+        if hero_cached_cover then hero.cover_path=hero_cached_cover end
         hero.heading="最近阅读"
         hero.source_text=self:_home_source_text(hero)
         hero.last_read_text=self:_home_last_read_text(hero)


### PR DESCRIPTION
## 问题

觅阅下载书的记录里，`cover_path` 可能指向本地元数据生成的**极小封面缩略图**（如 `covers/local/*.png`，仅 79x117 像素）。锁屏（KOReader screensaver）把这张小图放大到全屏（如 KPW3 的 1072x1448）后，封面非常模糊。

此外还发现 `cover_index` 可能因后台下载/重建而缺少部分书籍的映射（文件存在但索引无记录）。

## 修改

`main.lua` 的 hero（最近阅读）构建处，优先使用觅阅的高清封面：

1. 先查 `cover_index`（`cached_cover_path`）；
2. 索引缺失时，**直接按标准路径探测** `covers/<bookId>.<ext>`（jpg/png/gif/webp/svg）并校验；
3. 都拿不到才回退到原来的 `cover_path`（本地小图）。

这样锁屏和主页 hero 都能显示高清原图封面。

## 验证

- 本地 Lua 5.1 全插件语法检查通过（74 个文件）；
- 真机（Kindle Paperwhite 3 + KOReader）：该书高清封面 1080x1608，修复前锁屏放大 79x117 小图模糊；修复后锁屏显示清晰原图。