### PR TITLE
修复 txt 网文章节标题与目录丢失"第X章"字样的问题

### DIFF
--- a/miuread.koplugin/miuread/downloader.lua
+++ b/miuread.koplugin/miuread/downloader.lua
@@ -670,6 +670,17 @@ end
 function Downloader:catalog(id)
     local catalog = self.reader:catalog(id)
     local source = catalog.updated or catalog.chapterInfos or catalog.chapters or {}
+    -- The chapterInfos response does not report the book format. Read it from
+    -- the reader page context instead; on failure keep the raw titles rather
+    -- than guessing.
+    local book_format
+    local ok_state, state = pcall(self.reader.state, self.reader, id)
+    if ok_state and type(state) == "table" and type(state.book) == "table" then
+        book_format = state.book.format
+    else
+        logger.warn("[MiuRead][Download] book format unavailable; keeping raw catalog titles",
+            "book=", tostring(id), "error=", ok_state and "reader context has no book info" or tostring(state))
+    end
     local out, seen = {}, {}
     for index, chapter in ipairs(source) do
         local uid = tostring(chapter.chapterUid or chapter.uid or "")
@@ -682,6 +693,18 @@ function Downloader:catalog(id)
             and not self.reader._is_cover_chapter(chapter)
             and not self.reader._is_unavailable_chapter(chapter) then
             seen[uid] = true
+            -- The official web reader displays every catalog title of a txt
+            -- (web novel) book as "第{chapterIdx}章 {title}" and uses EPUB
+            -- titles as-is. Mirror that rule so headings and the TOC match
+            -- the official display.
+            if book_format == "txt" then
+                local idx = tonumber(chapter.chapterIdx)
+                if idx then
+                    local title = tostring(chapter.title or "")
+                    chapter.title = title == "" and ("第" .. tostring(idx) .. "章")
+                        or ("第" .. tostring(idx) .. "章 " .. title)
+                end
+            end
             if tostring(chapter.title or ""):gsub("%s+", "") == "" then
                 chapter.title = "第 " .. tostring(#out + 1) .. " 节"
             end


### PR DESCRIPTION
## 问题

txt 格式网文(如《重生之女将星》《良陈美锦》《岁时来仪》)下载后,目录与正文章节标题丢失"第X章"字样("第一章 女将"变成"女将");epub 出版书籍(如《绿山墙的安妮》)则正常

## 原因

微信读书对 txt 网文,`/web/book/chapterInfos` 返回的章节 `title` 本就不含"第X章";官方 web 端在展示层按 `第{chapterIdx}章 {title}` 拼接后显示(官方前端 `chapterTitleText` 逻辑:非 epub 书一律加前缀,epub 书原样,无任何按标题内容的特判)，插件直接使用单独 title,因此丢失

补充说明:chapterInfos 响应中没有 `format` 字段,`Downloader:catalog` 下游原有的 `catalog.format` 判断实际命中不了;txt 书籍能正常下载依靠 `Reader:_epub_once` / `_chapter_once` 的 epub→txt 自动回退

## 修改

仅改 `miuread.koplugin/miuread/downloader.lua` 的 `Downloader:catalog`,+23 行:

- 通过现有的 `Reader:state`读取阅读页 `__INITIAL_STATE__` 中的 `bookInfo.format`;
- `format == "txt"` 且 `chapterIdx` 可数值化时,标题补全为 `第{chapterIdx}章 {title}`(与官方显示一致;楔子、番外等特殊章节一并带前缀,同官方处理方式);
- epub 书籍不进入该分支,标题零变化;format 获取失败时保持原标题并记 warning——可能"漏加",但不会"错加";
- 未改动下载路径选择与 `manifest.format` 相关逻辑,不影响既有缓存判定。

## 需要知道的行为(与既有笔记保护机制的交互)

- 对**之前已下载过**的书重新执行"划线与想法版"下载且存在断点缓存时:目录(TOC)标题会全部更新,但已完成章节的**正文内**标题保持旧样式——这沿用插件现有设计(只更新 `entry.title`、不重写已完成 XHTML,避免 KOReader 本地笔记错位)。若希望正文也全部更新,删除该书数据目录下的 `.miuread-partial-…` 断点缓存后重新下载即可(划线/想法会重新抓取)。
- "纯净版"下载每次全量重建,所以无此现象

## 测试

- 环境:Android 13 阅读器(KOReader)
- txt 网文:《重生之女将星》《良陈美锦》《岁时来仪》——目录与正文标题均正确带"第X章"
- epub 出版书:《绿山墙的安妮》(含样式)——标题与样式无任何变化
- 另外用官方web端数据对 4 本书共 2439 个章节逐一比对标题拼接结果,与官方显示相较目前看来无差异(含楔子"第1章 楔子 …"、番外;epub 书"版权信息"等条目原样保留)