### PR TITLE
fix: 从觅阅主页打开文件夹选择器时崩溃 (filechooser.lua:336 attempt to index field 'ui')

### DIFF
--- a/miuread.koplugin/main.lua
+++ b/miuread.koplugin/main.lua
@@ -18868,7 +18868,18 @@ function Plugin:_add_local_root_path(path)
     save(); return true
 end
 
+function Plugin:_ensure_path_chooser_base()
+    -- PathChooser:init() takes its ui from ReaderUI.instance or
+    -- FileManager.instance and FileChooser dereferences it unguarded
+    -- (folder_shortcuts, PathChanged). Opened straight from the MiuRead home
+    -- neither instance exists, so the chooser errors out inside new().
+    local ok,ReaderUI=pcall(require,"apps/reader/readerui")
+    if ok and ReaderUI and ReaderUI.instance then return true end
+    return self:_ensure_filemanager_base(HOME_RETURN_FILE,{conceal_under_home=true})==true
+end
+
 function Plugin:add_local_root_dialog()
+    if not self:_ensure_path_chooser_base() then self:info("暂时无法打开文件夹选择器，请稍后重试"); return end
     local current="/mnt/us/documents"
     if lfs.attributes(current,"mode")~="directory" then
         current=lfs.attributes("/mnt/onboard","mode")=="directory" and "/mnt/onboard" or "/mnt/us"
@@ -19482,6 +19493,7 @@ function Plugin:_validate_download_dir(path)
     return true
 end
 function Plugin:directory_dialog()
+    if not self:_ensure_path_chooser_base() then self:info("暂时无法打开文件夹选择器，请稍后重试"); return end
     local current=self:_download_dir_path()
     if lfs.attributes(current,"mode")~="directory" then
         if lfs.attributes("/mnt/us/documents","mode")=="directory" then current="/mnt/us/documents"


### PR DESCRIPTION
## 问题

在觅阅主页（首页与书架 → 本地书籍 → 添加本地书库目录）点开文件夹选择器，弹窗画不出来，报错并中断：

```
frontend/ui/widget/filechooser.lua:336: attempt to index field 'ui' (a nil value)
stack traceback:
	frontend/ui/widget/filechooser.lua:336: in function 'refreshPath'
	frontend/ui/widget/filechooser.lua:104: in function 'init'
	frontend/ui/widget/pathchooser.lua:53: in function 'init'
	frontend/ui/widget/widget.lua:46: in function 'new'
	plugins/miuread.koplugin/main.lua:17551: in function 'add_local_root_dialog'
	plugins/miuread.koplugin/main.lua:17704: in function <plugins/miuread.koplugin/main.lua:17704>
```

设备：Kindle Scribe（KOReader + 觅阅 4.5.0）。`main.lua` 行号为 v4.5.0；当前 main 分支同一处代码未变。

## 原因

`PathChooser:init()` 里 ui 是写死取的：

```lua
self.ui = require("apps/reader/readerui").instance or require("apps/filemanager/filemanager").instance
```

而 `FileChooser` 对它不做保护地解引用（`refreshPath` 里的 `self.ui.folder_shortcuts`，还有 `genItemTableFromPath`、`changeToPath` 里的 `self.ui:handleEvent(...)`）。从觅阅主页直接开选择器时，ReaderUI 和 FileManager 两个 instance 都不存在，`self.ui` 为 nil，于是在 `PathChooser:new{}` 内部就抛出去了。

因为 `self.ui` 是 `init()` 内部无条件覆盖的，从外面传 `ui=` 没用；插件侧的解法是先保证 instance 存在。

## 改动

新增 `Plugin:_ensure_path_chooser_base()`，在两个 `PathChooser:new` 调用点（`add_local_root_dialog` / `directory_dialog`）之前先建一个 FileManager base。用的是插件里已有的 `_ensure_filemanager_base(...)`，并带上 `conceal_under_home=true`，避免闪一帧原生文件浏览器。建不出来时给一句提示而不是崩。

只加 12 行，没有动既有逻辑。

## 验证

- 打补丁前后都在 Kindle Scribe（KOReader，觅阅 4.5.0）实机跑过：修复前必崩，修复后选择器正常打开、长按文件夹能选中、目录成功加入本地书库并扫描出书。
- 补丁 cherry-pick 到当前 main（77c3d15）后 `luajit -bl` 语法检查通过。
- 另一处 `directory_dialog`（选择下载文件夹）是同一根因，一并加了，未单独实机复现。
