### PR TITLE
fix: 兼容旧版 KOReader 并完整锁定屏幕方向

### DIFF
--- a/miuread.koplugin/miuread/orientation_controller.lua
+++ b/miuread.koplugin/miuread/orientation_controller.lua
@@ -39,6 +39,56 @@ local function native_call(name, ...)
     return result == false and false or true
 end
 
+-- KOReader only gained the explicit onSetLockGSensor(flag) action recently.
+-- Older releases expose onLockGSensor(), which toggles the persisted setting.
+-- Normalize both APIs to an idempotent setter so MiuRead works with either one.
+local function set_native_gsensor_lock(target)
+    target = target == true
+    if setting_true("input_lock_gsensor") == target then return true end
+
+    local listener = device_listener()
+    if not listener then return false, "KOReader 方向控制暂时不可用" end
+
+    local ok, message
+    if type(listener.onSetLockGSensor) == "function" then
+        ok, message = native_call("onSetLockGSensor", target)
+    elseif type(listener.onLockGSensor) == "function" then
+        ok, message = native_call("onLockGSensor")
+    else
+        return false, "当前 KOReader 版本不支持方向锁定"
+    end
+    if not ok then return false, message end
+
+    if setting_true("input_lock_gsensor") ~= target then
+        logger.warn("[MiuRead][Orientation] lock state unchanged", "target=", tostring(target))
+        return false, "KOReader 方向锁定状态未生效"
+    end
+    return true
+end
+
+-- KOReader's native "GSensor lock" only locks the orientation family: it
+-- still allows Portrait <-> Inverted Portrait and Landscape <-> Inverted
+-- Landscape. MiuRead's "lock current orientation" promises a complete freeze,
+-- so suspend accelerometer rotation events instead.
+local function set_gsensor_events(enabled)
+    enabled = enabled == true
+    local target_ignored = not enabled
+    if setting_true("input_ignore_gsensor") == target_ignored then return true end
+
+    local ok, message = native_call("onToggleGSensor")
+    if not ok then return false, message end
+    if setting_true("input_ignore_gsensor") ~= target_ignored then
+        logger.warn("[MiuRead][Orientation] accelerometer state unchanged",
+            "enabled=", tostring(enabled))
+        return false, "KOReader 自动旋转状态未生效"
+    end
+    return true
+end
+
+local function set_orientation_locked(target)
+    return set_gsensor_events(target ~= true)
+end
+
 function M.has_gsensor()
     if not Device or type(Device.hasGSensor) ~= "function" then return false end
     local ok, value = pcall(Device.hasGSensor, Device)
@@ -60,16 +110,17 @@ function M.rotation_label()
     return "竖屏"
 end
 
--- Compatibility name retained for existing MiuRead UI callers. The value is
--- now KOReader's own persistent lock state, not a second MiuRead session flag.
+-- Compatibility name retained for existing MiuRead UI callers.
 function M.is_session_locked()
-    return setting_true("input_lock_gsensor")
+    return setting_true("input_ignore_gsensor")
 end
 
 function M.status_label()
     if not M.has_gsensor() then return M.rotation_label() end
-    if setting_true("input_ignore_gsensor") then return "KOReader 已关闭自动旋转" end
-    if setting_true("input_lock_gsensor") then return "已锁定 · " .. M.rotation_label() end
+    if setting_true("input_ignore_gsensor") then return "已锁定 · " .. M.rotation_label() end
+    if setting_true("input_lock_gsensor") then
+        return "KOReader 已限制横竖屏 · " .. M.rotation_label()
+    end
     return "自动旋转"
 end
 
@@ -82,18 +133,18 @@ end
 
 function M.lock_current()
     if not M.has_gsensor() then return false, "当前设备没有自动旋转传感器" end
-    local ok, message = native_call("onSetLockGSensor", true)
+    local ok, message = set_orientation_locked(true)
     return ok, ok and "已使用 KOReader 锁定当前方向" or message
 end
 
 function M.follow_koreader()
     if not M.has_gsensor() then return true, "当前设备使用手动方向" end
-    if setting_true("input_lock_gsensor") then
-        local ok, message = native_call("onSetLockGSensor", false)
+    if setting_true("input_ignore_gsensor") then
+        local ok, message = set_orientation_locked(false)
         if not ok then return false, message end
     end
-    if setting_true("input_ignore_gsensor") then
-        return true, "已跟随 KOReader；KOReader 当前关闭了自动旋转"
+    if setting_true("input_lock_gsensor") then
+        return true, "已跟随 KOReader；当前保留横竖屏限制"
     end
     return true, "已跟随 KOReader 自动旋转"
 end
@@ -101,11 +152,11 @@ end
 function M.enable_auto_rotation()
     if not M.has_gsensor() then return false, "当前设备没有自动旋转传感器" end
     if setting_true("input_lock_gsensor") then
-        local ok, message = native_call("onSetLockGSensor", false)
+        local ok, message = set_native_gsensor_lock(false)
         if not ok then return false, message end
     end
     if setting_true("input_ignore_gsensor") then
-        local ok, message = native_call("onToggleGSensor")
+        local ok, message = set_gsensor_events(true)
         if not ok then return false, message end
     end
     return true, "已通过 KOReader 恢复自动旋转"
@@ -123,7 +174,7 @@ function M.set_fixed(mode)
         return false, "屏幕方向切换失败"
     end
     if M.has_gsensor() then
-        local locked, message = native_call("onSetLockGSensor", true)
+        local locked, message = set_orientation_locked(true)
         if not locked then return false, message end
     end
     return true, M.has_gsensor() and "已通过 KOReader 固定屏幕方向" or "已切换屏幕方向"
@@ -139,11 +190,8 @@ end
 
 function M.toggle_session_lock()
     if not M.has_gsensor() then return false, "当前设备没有自动旋转传感器" end
-    if setting_true("input_ignore_gsensor") then
-        return false, "KOReader 当前已关闭自动旋转；长按可选择恢复自动旋转"
-    end
-    local target = not setting_true("input_lock_gsensor")
-    local ok, message = native_call("onSetLockGSensor", target)
+    local target = not setting_true("input_ignore_gsensor")
+    local ok, message = set_orientation_locked(target)
     if not ok then return false, message end
     return true, target and "已使用 KOReader 锁定当前方向" or "已解除方向锁定"
 end


### PR DESCRIPTION
## 问题

觅阅的方向锁定直接调用 `onSetLockGSensor(flag)`，但较旧的 KOReader 只提供 `onLockGSensor()`，因此锁定操作可能无效。

此外，KOReader 原生的 `input_lock_gsensor` 只锁定横屏/竖屏类别，仍允许：

- 正向竖屏 ↔ 倒置竖屏
- 向左横屏 ↔ 向右横屏

这与觅阅“锁定当前方向”的用户预期不一致。

## 修改

- 兼容新旧 KOReader 方向锁定接口，并将切换式旧接口封装为幂等设置
- “锁定当前方向”改为暂停加速度计旋转事件，从而固定四个具体方向
- “跟随 KOReader”只解除觅阅的完整冻结，保留 KOReader 自己的横竖屏限制
- “恢复自动旋转”同时解除完整冻结和 KOReader 原生限制
- 更新状态文案，区分“完全锁定”和“KOReader 横竖屏限制”

## 验证

复现设备：

- Kindle Oasis 3（KOA3）
- Kindle 固件 5.18.2.1.1
- KOReader commit `5cd9494ae`（2025-01-10）
- MiuRead 4.8.0

本地 Lua 模拟测试通过 8 个用例，覆盖：

- 旧版 `onLockGSensor()`
- 新版 `onSetLockGSensor(flag)`
- 完整方向冻结及重复锁定
- 固定横屏
- 跟随 KOReader 时保留原生限制
- 恢复自动旋转
- 不支持的监听器与无 GSensor 设备

实机测试通过：锁定后左右摆放、正向竖屏与倒置竖屏之间均不会自动旋转；解除锁定后自动旋转可正常恢复。