### PR TITLE
fix: restore CSS-backed EPUB part images

### DIFF
--- a/miuread.koplugin/miuread/downloader.lua
+++ b/miuread.koplugin/miuread/downloader.lua
@@ -30,7 +30,7 @@ local LEGACY_TITLE_TRANSFORM_VERSION = 1
 local TITLE_TRANSFORM_VERSION = 2
 local LEGACY_ANNOTATION_TRANSFORM_VERSION = 1
 local ANNOTATION_TRANSFORM_VERSION = 5
-local IMAGE_TRANSFORM_VERSION = 2
+local IMAGE_TRANSFORM_VERSION = 3
 local LEGACY_CONTENT_TRANSFORM_VERSION = 1
 local CONTENT_TRANSFORM_VERSION = 2
 
@@ -703,9 +703,25 @@ local function txt_catalog_title(title, chapter_idx)
         or ("第" .. tostring(idx) .. "章 " .. title)
 end
 
+local function catalog_resource_namespace(source, book_id)
+    local expected=tostring(book_id or "")
+    local found
+    for _,chapter in ipairs(source or {}) do
+        local namespace=tostring(chapter.tar or ""):match("/tar_([%w_-]+)_%d+")
+        if namespace then
+            local suffix=namespace:match("([^_]+)$") or namespace
+            if expected=="" or suffix~=expected then return nil,true end
+            if found and found~=namespace then return nil,true end
+            found=namespace
+        end
+    end
+    return found or expected,false
+end
+
 function Downloader:catalog(id, request_options)
     local catalog = self.reader:catalog(id, request_options)
     local source = catalog.updated or catalog.chapterInfos or catalog.chapters or {}
+    local resource_namespace,resource_ambiguous=catalog_resource_namespace(source,id)
     -- chapterInfos does not reliably expose the book format. Use the reader
     -- page context when available; on failure keep the source titles unchanged.
     local book_format
@@ -721,6 +737,8 @@ function Downloader:catalog(id, request_options)
         local uid = tostring(chapter.chapterUid or chapter.uid or "")
         chapter._miuread_has_children = catalog_has_children(source, index)
         chapter._miuread_catalog_index = index
+        chapter._miuread_resource_book_id = resource_namespace
+        chapter._miuread_resource_book_ambiguous = resource_ambiguous
         -- Do not decide readability from title or wordCount. Those fields are
         -- hints only and are inconsistent for short, image-only and special
         -- catalog items. Actual EPUB/TXT responses determine the result.
@@ -2193,6 +2211,7 @@ Downloader._prepare_chapter_body_legacy = prepare_chapter_body_legacy
 Downloader._prepare_chapter_body_current = prepare_chapter_body_current
 Downloader._namespace_assets = namespace_assets
 Downloader._catalog_signature = catalog_signature
+Downloader._catalog_resource_namespace = catalog_resource_namespace
 Downloader._option_key = option_key
 Downloader._validate_epub = function(path,expected)
     if type(expected)=="number" then

--- a/miuread.koplugin/miuread/reader.lua
+++ b/miuread.koplugin/miuread/reader.lua
@@ -213,7 +213,12 @@ local function image_only_xhtml(assets)
 end
 
 local function readable_text_length(html)
-    return #visible_text(html)
+    local text=tostring(html or ""):gsub("<[^>]+>"," ")
+    text=text:gsub("&[nN][bB][sS][pP];",""):gsub("&#0*160;","")
+        :gsub("&#[xX]0*[aA]0;",""):gsub("&#0*12288;","")
+        :gsub("&#[xX]0*3000;",""):gsub("\194\160",""):gsub("\227\128\128","")
+        :gsub("%s+","")
+    return #text
 end
 
 local function is_empty_error(value)
@@ -414,6 +419,82 @@ local function image_remote_url(value)
     if url:match("^https?://") then return url end
 end
 
+local function image_is_safe_weread_url(value)
+    local url=image_remote_url(value)
+    local host=url and url:lower():match("^https?://([^/:]+)") or nil
+    return host=="weread.qq.com" or (host and host:sub(-14)==".weread.qq.com") or false
+end
+
+local function image_url_path_encode(value)
+    return (tostring(value or ""):gsub("([^%w%-%._~/])",function(char)
+        return string.format("%%%02X",char:byte())
+    end))
+end
+
+local function image_weread_resource_url(value,state)
+    local clean=image_trim(value)
+    if clean=="" or clean:match("^https?://") or clean:sub(1,2)=="//" then return nil end
+    local raw_path=clean:match("^[^%?#]+") or clean
+    if raw_path:find("\\",1,true) then return nil end
+    local undecoded=raw_path:gsub("%%[%x][%x]","")
+    if undecoded:find("%",1,true) then return nil end
+    local path=image_url_decode(raw_path)
+    if path:find("\\",1,true) then return nil end
+    if not path:lower():match("^%.%./images/") then return nil end
+    local namespace=tostring(state and state.image_resource_book_id or "")
+    if namespace=="" or not namespace:match("^[%w_-]+$") then return nil end
+    local relative=path:sub(11)
+    if relative=="" or relative:sub(1,1)=="/" or relative:sub(-1)=="/"
+        or relative:find("//",1,true) or relative:find("[%z\1-\31\127]") then return nil end
+    for segment in (relative.."/"):gmatch("(.-)/") do
+        if segment=="" or segment=="." or segment==".." then return nil end
+    end
+    return "https://res.weread.qq.com/wrepub/web/"..namespace.."/"..image_url_path_encode(relative)
+end
+
+local function css_body_background_source(xhtml,css)
+    local attrs=tostring(xhtml or ""):match("<[bB][oO][dD][yY]([^>]*)>")
+    local classes=attrs and image_attr(attrs,"class") or ""
+    local active={}
+    for class in tostring(classes):gmatch("[^%s]+") do active["."..class]=true end
+    local source
+    local clean_css=tostring(css or ""):gsub("/%*.-%*/","")
+    for selectors,block in clean_css:gmatch("([^{}]+)(%b{})") do
+        local matches=false
+        for selector in selectors:gmatch("[^,]+") do
+            selector=image_trim(selector)
+            if active[selector] then matches=true; break end
+        end
+        if matches then
+            for declaration in block:sub(2,-2):gmatch("[^;]+") do
+                local property,value=declaration:match("^%s*([%w%-]+)%s*:%s*(.-)%s*$")
+                property=tostring(property or ""):lower()
+                if property=="background" then return nil,true end
+                if property=="background-image" then
+                    local values={}
+                    for _,candidate in tostring(value or ""):gmatch([=[[uU][rR][lL]%s*%(%s*(["']?)(.-)%1%s*%)]=]) do
+                        candidate=image_trim(candidate)
+                        if candidate~="" then values[#values+1]=candidate end
+                    end
+                    if #values~=1 then return nil,true end
+                    local remainder=tostring(value or ""):gsub([=[[uU][rR][lL]%s*%(%s*(["']?)(.-)%1%s*%)]=],"",1)
+                        :gsub("%s*![iI][mM][pP][oO][rR][tT][aA][nN][tT]%s*$",""):gsub("%s+","")
+                    if remainder~="" then return nil,true end
+                    if source and source~=values[1] then return nil,true end
+                    source=values[1]
+                end
+            end
+        end
+    end
+    return source,false
+end
+
+local function xhtml_first_heading(xhtml)
+    local tag,attrs,inner=tostring(xhtml or ""):match("<([hH][1-6])([^>]*)>(.-)</%1%s*>")
+    if not tag then return nil end
+    return "<"..tag..attrs..">"..inner.."</"..tag..">"
+end
+
 local function image_is_font_reference(value)
     local clean=image_trim(value):lower():gsub("[?#].*$", "")
     return clean:match("%.woff2?$") ~= nil
@@ -496,6 +577,8 @@ local function localize_epub_images(reader, xhtml, assets, source_map, state, cs
         optional_dropped=0,stale_dropped=0,embedded=0,fonts_skipped=0,
     }
     local text_length = readable_text_length(xhtml)
+    local active_background,background_ambiguous=css_body_background_source(xhtml,css)
+    local source_heading=xhtml_first_heading(xhtml)
 
     -- WeRead chapter CSS may reference remote web fonts. Fonts are presentation
     -- resources, not正文 images: a dead font CDN must never make a chapter
@@ -575,15 +658,49 @@ local function localize_epub_images(reader, xhtml, assets, source_map, state, cs
         return href
     end
 
-    local function resolve_source(source, prefix)
+    local function resolve_source(source, prefix, allow_web_resource)
         local clean=image_trim(source)
         if clean=="" or clean:sub(1,1)=="#" or clean:lower():match("^data:image/") then return nil,nil end
         local mapped=image_map_get(source_map,clean)
         local href=mapped and normalize_asset_href(mapped) or nil
         local remote_url=image_remote_url(clean)
+        if not remote_url and allow_web_resource then
+            remote_url=image_weread_resource_url(clean,state)
+        end
         if not href and remote_url then href=download_remote(remote_url) end
         if href and href~="" then return tostring(prefix or "")..href,href end
         return nil,nil,remote_url~=nil
+    end
+
+    -- Some EPUB part/divider pages contain only whitespace and paint their
+    -- artwork through a body-class background in the shared stylesheet. Turn
+    -- that one active background into an ordinary EPUB image; otherwise the
+    -- unrelated shared CSS references can be discarded and leave a blank page.
+    if text_length==0 and source_heading and active_background and not background_ambiguous then
+        local background=active_background
+        summary.discovered=summary.discovered+1
+        summary.required_discovered=summary.required_discovered+1
+        local mapped=image_map_get(source_map,background)
+        local remote=image_remote_url(background)
+        local trusted=mapped~=nil or remote==nil or image_is_safe_weread_url(remote)
+        local _,href
+        if trusted then _,href=resolve_source(background,"",true) end
+        if href then
+            summary.localized=summary.localized+1
+            summary.required_localized=summary.required_localized+1
+            local page='<div class="miu-image-only-title-marker">'..source_heading.."</div>"
+                ..image_only_xhtml({{href=href}})
+            return page,assets,summary,[[
+.miu-image-only-title-marker { display: none !important; }
+.miu-image-only-page { text-align: center; }
+.miu-image-only-item { margin: 0; }
+.miu-image-only-item img { display: inline-block; max-width: 100%; height: auto; }
+]]
+        end
+        summary.missing=summary.missing+1
+        summary.required_missing=summary.required_missing+1
+        logger.warn("[MiuRead][Reader] body background image unresolved","src=",tostring(background))
+        return xhtml,assets,summary,css or ""
     end
 
     -- EPUBs often use <picture><source srcset=...><img ...></picture>.
@@ -629,7 +746,7 @@ local function localize_epub_images(reader, xhtml, assets, source_map, state, cs
         summary.discovered=summary.discovered+1
         summary.required_discovered=summary.required_discovered+1
 
-        local local_src,href,was_remote = resolve_source(clean_source,"../")
+        local local_src,href,was_remote = resolve_source(clean_source,"../",true)
         if local_src then
             used_local_src[href] = true
             summary.localized = summary.localized + 1
@@ -659,7 +776,7 @@ local function localize_epub_images(reader, xhtml, assets, source_map, state, cs
         end
         summary.discovered=summary.discovered+1
         summary.required_discovered=summary.required_discovered+1
-        local local_src,href,was_remote=resolve_source(clean,"../")
+        local local_src,href,was_remote=resolve_source(clean,"../",true)
         if local_src then
             used_local_src[href]=true
             summary.localized=summary.localized+1
@@ -679,7 +796,7 @@ local function localize_epub_images(reader, xhtml, assets, source_map, state, cs
 
     -- Some illustrated books place images in inline or chapter CSS rather than
     -- img tags. Resolve url(...) against the same TAR/remote asset map.
-    local function localize_css_urls(value,prefix)
+    local function localize_css_urls(value,prefix,relative_source)
         return tostring(value or ""):gsub("url%s*%(%s*([\\\"']?)(.-)%1%s*%)",function(_,source)
             local clean=image_trim(source)
             if clean=="" or clean:sub(1,1)=="#" then
@@ -696,7 +813,8 @@ local function localize_epub_images(reader, xhtml, assets, source_map, state, cs
                 return "url("..tostring(source or "")..")"
             end
             summary.discovered=summary.discovered+1
-            local local_src,href,was_remote=resolve_source(clean,prefix)
+            local allow_web_resource=relative_source~=nil and clean==relative_source
+            local local_src,href,was_remote=resolve_source(clean,prefix,allow_web_resource)
             if local_src then
                 used_local_src[href]=true
                 summary.localized=summary.localized+1
@@ -717,9 +835,9 @@ local function localize_epub_images(reader, xhtml, assets, source_map, state, cs
         end)
     end
     xhtml=xhtml:gsub("([sS][tT][yY][lL][eE]%s*=%s*)([\\\"'])(.-)%2",function(prefix,quote,value)
-        return prefix..quote..localize_css_urls(value,"../")..quote
+        return prefix..quote..localize_css_urls(value,"../",nil)..quote
     end)
-    local localized_css=localize_css_urls(css or "","")
+    local localized_css=localize_css_urls(css or "","",nil)
 
     -- Some books contain valid TAR assets whose internal names no longer match
     -- the HTML paths. When the remaining counts match exactly, map them by order
@@ -983,6 +1101,8 @@ function Reader:_epub_once(book, chapter, opt, state)
     local id = tostring(book.bookId or book.book_id)
     local uid = chapter.chapterUid or chapter.uid
     state = state or self:state(id, uid)
+    state.image_resource_book_id=chapter._miuread_resource_book_ambiguous and nil
+        or tostring(chapter._miuread_resource_book_id or id)
 
     local a = self:shard("/web/book/chapter/e_0", id, uid, state.psvts, false)
     if a:match("^%s*{") and a:find('"bookId"', 1, true) then

--- a/tests/reader_background_regression.lua
+++ b/tests/reader_background_regression.lua
@@ -1,0 +1,193 @@
+local function preload(name,value)
+    package.preload[name]=function() return value end
+end
+
+local fixture_exists=true
+local fixture_mime="image/jpeg"
+local download_mode="ok"
+
+preload("miuread.json",{})
+preload("miuread.protocol",{})
+preload("miuread.cookies",{})
+preload("miuread.http",{is_auth_error=function(value) return tostring(value):find("AUTH",1,true)~=nil end})
+preload("miuread.codec",{
+    media_file=function() return ".jpg",fixture_mime end,
+    body=function(html) return tostring(html):match("<body[^>]*>(.*)</body>") or html end,
+})
+preload("miuread.annotation_coord",{})
+preload("miuread.util",{
+    file_exists=function() return fixture_exists end,
+    redact_url=function(value) return value end,
+    xml=function(value) return value end,
+})
+preload("logger",{warn=function() end,info=function() end,dbg=function() end})
+
+local reader_path=assert(arg[1],"reader.lua path required")
+local Reader=assert(loadfile(reader_path))()
+local fixture="/tmp/fixture.jpg"
+local requested={}
+local stub={
+    store={temp_dir="/tmp"},
+    http={
+        download_to_file=function(_,url)
+            requested[#requested+1]=url
+            if download_mode=="auth" then error("AUTH") end
+            return fixture
+        end,
+    },
+}
+local base_state={
+    image_work_root="/tmp",
+    url="https://weread.qq.com/web/reader/test",
+    image_resource_book_id="CB_26713355",
+}
+
+local function localize(xhtml,css,assets,source_map,state)
+    requested={}
+    return Reader._localize_epub_images(stub,xhtml,assets or {},source_map or {},state or base_state,css or {},{})
+end
+
+local function assert_not_image_page(body)
+    assert(not body:find("miu%-image%-only%-page"),body)
+end
+
+local page='<html><body class="copyright-basemap3"><h1 title="第一部分">　　　</h1></body></html>'
+local css=[[
+/* .copyright-basemap3 { background-image: url('../Images/wrong.jpg'); } */
+.copyright-basemap3 { background-image: url('../Images/chapter1.jpg'); }
+]]
+local body,assets,summary=localize(page,css)
+assert(requested[1]=="https://res.weread.qq.com/wrepub/web/CB_26713355/chapter1.jpg","initial request="..tostring(requested[1]))
+assert(#requested==1 and #assets==1)
+assert(body:find('../images/remote%-0001%.jpg')~=nil,body)
+assert(body:find('miu%-image%-only%-title%-marker')~=nil,body)
+assert(not body:find('miu%-chapter%-title'),body)
+assert(summary.required_localized==1 and summary.required_missing==0)
+local image_body=body
+
+body,assets,summary=localize(page,[[.copyright-basemap3 { background-image: url('../Images/parts/chapter 1.jpg'); }]])
+assert(requested[1]=="https://res.weread.qq.com/wrepub/web/CB_26713355/parts/chapter%201.jpg","nested request="..tostring(requested[1]))
+assert(#assets==1 and summary.required_localized==1)
+
+local numeric_state={image_work_root="/tmp",url=base_state.url,image_resource_book_id="26713355"}
+body,assets,summary=localize(page,[[.copyright-basemap3 { background-image: url('../Images/chapter1.jpg'); }]],nil,nil,numeric_state)
+assert(requested[1]=="https://res.weread.qq.com/wrepub/web/26713355/chapter1.jpg","numeric request="..tostring(requested[1]))
+assert(#assets==1 and summary.required_localized==1)
+
+body,assets,summary=localize('<html><body class="part"><h1>序</h1></body></html>',[[.part { background-image: url('../Images/decor.jpg'); }]])
+assert(#requested==0)
+assert_not_image_page(body)
+
+body,assets,summary=localize('<html><body class="part alternate"><h1 title="第一部分">　</h1></body></html>',[[
+.part { background-image: url('../Images/one.jpg'); }
+.alternate { background-image: url('../Images/two.jpg'); }
+]])
+assert(#requested==0)
+assert_not_image_page(body)
+
+body,assets,summary=localize(page,[[.copyright-basemap3 { background-image: url('../Images/one.jpg'), url('../Images/two.jpg'); }]])
+assert(#requested==0)
+assert_not_image_page(body)
+
+body,assets,summary=localize(page,[[.copyright-basemap3 { background: center / cover url('../Images/chapter1.jpg'); }]])
+assert(#requested==0)
+assert_not_image_page(body)
+
+body,assets,summary=localize(page,[[.copyright-basemap3 { background-image: linear-gradient(#fff,#000), url('../Images/chapter1.jpg'); }]])
+assert(#requested==0)
+assert_not_image_page(body)
+
+body,assets,summary=localize('<html><body class="part"><h1>&copy;</h1></body></html>',[[.part { background-image: url('../Images/decor.jpg'); }]])
+assert(#requested==0)
+assert_not_image_page(body)
+
+body,assets,summary=localize(page,[[.copyright-basemap3 { background-image: url('https://example.test/decor.jpg'); }]])
+assert(#requested==0 and #assets==0)
+assert(summary.required_missing==1)
+
+local ambiguous_state={image_work_root="/tmp",url=base_state.url}
+body,assets,summary=localize(page,css,nil,nil,ambiguous_state)
+assert(#requested==0 and #assets==0)
+assert(summary.required_missing==1)
+
+body,assets,summary=localize('<html><body class="copyright-basemap3"><div>　</div></body></html>',css)
+assert(#requested==0)
+assert_not_image_page(body)
+
+for _,bad in ipairs({
+    "../Images/../secret.jpg",
+    "../Images/parts\\secret.jpg",
+    "../Images/parts%5Csecret.jpg",
+    "../Images/chapter%ZZ.jpg",
+    "../Images/parts//chapter.jpg",
+}) do
+    body,assets,summary=localize(page,".copyright-basemap3 { background-image: url('"..bad.."'); }")
+    assert(#requested==0,bad)
+    assert(#assets==0,bad)
+    assert(summary.required_missing==1,bad.." missing="..tostring(summary.required_missing))
+end
+
+fixture_exists=false
+body,assets,summary=localize(page,css)
+assert(#requested==1 and #assets==0)
+assert(summary.required_missing==1)
+fixture_exists=true
+
+fixture_mime="text/html"
+body,assets,summary=localize(page,css)
+assert(#requested==1 and #assets==0)
+assert(summary.required_missing==1)
+fixture_mime="image/jpeg"
+
+download_mode="auth"
+local ok,err=pcall(localize,page,css)
+assert(not ok and tostring(err):find("AUTH",1,true),tostring(err))
+download_mode="ok"
+
+body,assets,summary=localize('<html><body><h1>正文</h1><img data-src="https://example.test/figure.jpg" /></body></html>')
+assert(requested[1]=="https://example.test/figure.jpg","absolute request="..tostring(requested[1]))
+assert(#assets==1 and summary.required_localized==1)
+
+local tar_assets={{href="images/tar.jpg",data_path="/tmp/tar.jpg",mime="image/jpeg"}}
+body,assets,summary=localize('<html><body><h1>正文</h1><img src="../Images/tar.jpg" /></body></html>',nil,tar_assets,{["images/tar.jpg"]="../images/tar.jpg"})
+assert(#requested==0)
+assert(body:find('../images/tar%.jpg')~=nil,body)
+assert(summary.required_localized==1)
+
+body,assets,summary=localize('<html><body><h1>正文</h1><p style="background-image:url(\'../Images/decor.jpg\')">正文</p></body></html>')
+assert(#requested==0)
+assert(body:find("正文",1,true),body)
+
+print("reader background regression: ok")
+
+for _,name in ipairs({
+    "miuread.config","miuread.footnotes","miuread.resource_refs","miuread.internal_links",
+    "miuread.thoughts","miuread.epub","miuread.download_plan","miuread.download_database",
+    "miuread.epub_installer","miuread.book_integrity","miuread.source_position",
+}) do preload(name,{}) end
+local downloader_path=assert(arg[2],"downloader.lua path required")
+local Downloader=assert(loadfile(downloader_path))()
+
+local namespace,ambiguous=Downloader._catalog_resource_namespace({
+    {tar=""},
+    {tar="https://res.weread.qq.com/wrco/tar_CB_26713355_7"},
+    {tar="https://res.weread.qq.com/wrco/tar_CB_26713355_24"},
+},"26713355")
+assert(namespace=="CB_26713355" and ambiguous==false,tostring(namespace))
+
+namespace,ambiguous=Downloader._catalog_resource_namespace({},"26713355")
+assert(namespace=="26713355" and ambiguous==false)
+namespace,ambiguous=Downloader._catalog_resource_namespace({{tar="https://res.weread.qq.com/wrco/tar_26713355_1"}},"26713355")
+assert(namespace=="26713355" and ambiguous==false)
+namespace,ambiguous=Downloader._catalog_resource_namespace({
+    {tar="https://res.weread.qq.com/wrco/tar_CB_26713355_1"},
+    {tar="https://res.weread.qq.com/wrco/tar_ALT_26713355_2"},
+},"26713355")
+assert(namespace==nil and ambiguous==true)
+namespace,ambiguous=Downloader._catalog_resource_namespace({{tar="https://res.weread.qq.com/wrco/tar_CB_126713355_1"}},"26713355")
+assert(namespace==nil and ambiguous==true)
+
+local prepared=Downloader._prepare_chapter_body(image_body,"第一部分",2)
+assert(prepared:find('miu%-image%-only%-title%-marker')~=nil,prepared)
+assert(prepared:find('miu%-chapter%-title')==nil,prepared)
+print("catalog resource namespace regression: ok")


### PR DESCRIPTION
## 问题

部分EPUB 的“第一部分/第二部分/第三部分”页面没有正文图片标签，通过共享 CSS 的 body class 引用背景图。对应章节的 TAR 地址可能为空，实际图片位于 `CB_<bookId>` 资源命名空间。插件因此生成空白分部页；较严格的资源检查还可能在接近下载完成时报告“未能生成完整 EPUB”。

## 修复

- 仅当页面可见正文严格为空、存在原始标题节点，并且活动 body class 唯一确定一个背景资源时，才转换为纯图片页。
- 从目录中唯一有效的 TAR 地址推导 `CB_<bookId>` 命名空间；冲突时不猜测。
- 保留 `../Images/` 后的完整子目录，并拒绝路径穿越、反斜杠、空路径段和非法 URL 转义。
- 相对 CSS 远程回退仅用于已严格确认的纯图片页；资源必须来自 TAR 映射或可信微信读书地址。
- 保留原始标题节点作为隐藏语义标记，避免重新注入可见标题并兼容 #6。
- 已确认图片页的资源缺失、非图片或认证失败时明确失败，使旧 EPUB 不会被不完整结果覆盖。

## 验证

- Kindle LuaJIT 语法检查通过。
- 回归测试覆盖 CSS 注释、短正文、HTML 可见实体、多 class 冲突、多背景、简写、嵌套路径、路径穿越、命名空间冲突、第三方域名、缺失/非图片/认证失败，以及既有懒加载、TAR 和绝对远程图片行为。
- KPW6 上仅定向重建三个分部章节，其余正文断点保持不变。
- 三个分部页均只保留隐藏标题标记和本地图片；没有可见标题。
- 最终 EPUB 资源扫描：`missing=0`，`external=0`。
- 测试环境：kpw6，koreader版本2026.07.2