### PR TITLE
复用微信读书连接，整本下载耗时下降约四分之一

### DIFF
--- a/miuread.koplugin/miuread/config.lua
+++ b/miuread.koplugin/miuread/config.lua
@@ -177,6 +177,15 @@ local C = {
     LIGHTWEIGHT_DERIVATIVE_GAP = 1.1,
 
     AUTH_NOTICE_FAILURE_THRESHOLD = 2,
+
+    -- Reuse the TCP+TLS connection between consecutive requests to the same
+    -- WeRead origin. Enabled per request and only inside a download run: one
+    -- chapter needs five sequential requests, so dropping the handshakes is the
+    -- largest saving available without touching request pacing. Login, shelf,
+    -- progress, read-time and annotation requests never reuse a connection.
+    -- Set to false to put downloads back on one connection per request.
+    HTTP_KEEPALIVE = true,
+
     DOWNLOAD_AUTO_RESTARTS = 2,
     DOWNLOAD_DIAGNOSTIC_KEEP = 3,
 

--- a/miuread.koplugin/miuread/downloader.lua
+++ b/miuread.koplugin/miuread/downloader.lua
@@ -17,8 +17,26 @@ local U = require("miuread.util")
 local logger = require("logger")
 local ok_socket, socket = pcall(require, "socket")
 
+-- Time spent deliberately yielding to the UI or waiting out a stall. Counted
+-- separately from network time so an A/B download run can tell throttling
+-- apart from transfer cost.
+local throttle_seconds = 0
+
 local function pause(seconds)
+    throttle_seconds = throttle_seconds + math.max(0, tonumber(seconds) or 0)
     if ok_socket and socket and type(socket.sleep) == "function" then socket.sleep(seconds) end
+end
+
+local function now()
+    if ok_socket and socket and type(socket.gettime) == "function" then return socket.gettime() end
+    return os.time()
+end
+
+local function human_bytes(value)
+    value = tonumber(value) or 0
+    if value >= 1048576 then return string.format("%.1fMB", value / 1048576) end
+    if value >= 1024 then return string.format("%.0fkB", value / 1024) end
+    return tostring(math.floor(value)) .. "B"
 end
 
 local Downloader = {}
@@ -706,12 +724,13 @@ local function txt_catalog_title(title, chapter_idx)
 end
 
 function Downloader:catalog(id, request_options)
+    request_options = type(request_options) == "table" and request_options or {}
     local catalog = self.reader:catalog(id, request_options)
     local source = catalog.updated or catalog.chapterInfos or catalog.chapters or {}
     -- chapterInfos does not reliably expose the book format. Use the reader
     -- page context when available; on failure keep the source titles unchanged.
     local book_format
-    local ok_state, state = pcall(self.reader.state, self.reader, id)
+    local ok_state, state = pcall(self.reader.state, self.reader, id, request_options.keepalive)
     if ok_state and type(state) == "table" and type(state.book) == "table" then
         book_format = tostring(state.book.format or ""):lower()
     else
@@ -1180,9 +1199,14 @@ local function append_entry(chapters, assets, css_list, css_seen, entry, body_so
     chapters[#chapters + 1] = chapter
 end
 
-function Downloader:book(input, opt, progress)
+function Downloader:_book_once(input, opt, progress)
     opt = opt or {}
     progress = progress or function() end
+    local run_started = now()
+    local throttle_at_start = throttle_seconds
+    local http_at_start = type(self.http) == "table" and self.http.stats_snapshot
+        and self.http:stats_snapshot() or nil
+    local chapters_fetched, chapters_from_checkpoint = 0, 0
     local function respect_reader_priority(stage)
         local pause_logged=false
         local function worker_paused()
@@ -1315,7 +1339,8 @@ function Downloader:book(input, opt, progress)
         local max_poll=math.max(poll,tonumber(Config.DOWNLOAD_NETWORK_RECOVERY_MAX_POLL_SECONDS) or 15)
         while true do
             if opt.cancelled and opt.cancelled() then error("download cancelled") end
-            local ok,catalog,all=pcall(self.catalog,self,book.bookId,{on_retry=catalog_retry_notice})
+            local ok,catalog,all=pcall(self.catalog,self,book.bookId,
+                {on_retry=catalog_retry_notice,keepalive=true})
             if ok then
                 if catalog_wait_started then
                     progress("resume",0,1,book.title,{message="网络已恢复，正在继续读取目录"})
@@ -1820,6 +1845,7 @@ function Downloader:book(input, opt, progress)
                 if valid then
                     failure_map[uid] = nil
                     restricted_map[uid] = nil
+                    chapters_from_checkpoint = chapters_from_checkpoint + 1
                     return true
                 end
                 cached_style="完成章节结构无效："..tostring(validation_error)
@@ -1841,6 +1867,7 @@ function Downloader:book(input, opt, progress)
         end
 
         if not body then
+            chapters_fetched = chapters_fetched + 1
             progress("content", index, expected, chapter.title)
             local last_activity_at,last_activity_bytes=0,0
             local function chapter_activity(kind,detail)
@@ -1859,6 +1886,9 @@ function Downloader:book(input, opt, progress)
                 self.reader.chapter, self.reader, book, chapter, format, {
                     images=opt.images,
                     activity=chapter_activity,
+                    -- Chapter content is the only place where reuse is enabled:
+                    -- five sequential requests to the same origin per chapter.
+                    keepalive=true,
                     yield=function(stage) respect_reader_priority(stage or "images") end,
                 })
             if not ok then
@@ -2271,7 +2301,61 @@ function Downloader:book(input, opt, progress)
     else
         U.remove_tree(cache.root)
     end
+    self:_log_run_summary(book, {
+        started = run_started,
+        throttle = throttle_seconds - throttle_at_start,
+        http_before = http_at_start,
+        chapters = #chapters,
+        fetched = chapters_fetched,
+        from_checkpoint = chapters_from_checkpoint,
+    })
     return record
+end
+
+-- Connection reuse is scoped to a single download run. However the run ends --
+-- finished, cancelled, or aborted by an error -- the pooled sockets are closed
+-- here, so none of them survives into a screen-off, a network change or the
+-- next task.
+function Downloader:book(input, opt, progress)
+    local ok, result = pcall(self._book_once, self, input, opt, progress)
+    if type(self.http) == "table" and type(self.http.close_idle_connections) == "function" then
+        pcall(self.http.close_idle_connections, self.http)
+    end
+    if not ok then error(result, 0) end
+    return result
+end
+
+-- One greppable line per completed download. `fetched` versus `checkpoint`
+-- matters when comparing two runs: a repeat download of the same book reuses
+-- its chapter checkpoints unless the partial directory was removed first, and
+-- a run with fetched=0 measured nothing.
+function Downloader:_log_run_summary(book, run)
+    local elapsed = math.max(0, now() - (tonumber(run.started) or 0))
+    local after = type(self.http) == "table" and self.http.stats_snapshot
+        and self.http:stats_snapshot() or nil
+    local before = run.http_before or {}
+    local function delta(field)
+        if not after then return 0 end
+        return (tonumber(after[field]) or 0) - (tonumber(before[field]) or 0)
+    end
+    local opened, reused = delta("connections_opened"), delta("connections_reused")
+    local requests = delta("requests")
+    logger.info("[MiuRead][Download] run summary",
+        "book=", tostring(book and book.bookId or ""),
+        "title=", tostring(book and book.title or ""),
+        "keepalive=", tostring(Config.HTTP_KEEPALIVE ~= false),
+        "chapters=", tostring(run.chapters or 0),
+        "fetched=", tostring(run.fetched or 0),
+        "checkpoint=", tostring(run.from_checkpoint or 0),
+        string.format("elapsed=%.1fs", elapsed),
+        string.format("network=%.1fs", delta("network_seconds")),
+        string.format("pacing=%.1fs", delta("pacing_seconds")),
+        string.format("ratelimit=%.1fs", delta("rate_limit_seconds")),
+        string.format("throttle=%.1fs", tonumber(run.throttle) or 0),
+        "requests=", tostring(requests),
+        "connections=", tostring(opened),
+        "reused=", tostring(reused),
+        "bytes=", human_bytes(delta("bytes")))
 end
 
 Downloader._prepare_chapter_body = prepare_chapter_body

--- a/miuread.koplugin/miuread/http.lua
+++ b/miuread.koplugin/miuread/http.lua
@@ -3,6 +3,7 @@ local socketutil = require("socketutil")
 local ok_http, http = pcall(require, "socket.http")
 local ok_https, https = pcall(require, "ssl.https")
 local ok_socket, socket = pcall(require, "socket")
+local ok_url, url_module = pcall(require, "socket.url")
 local ok_lfs, lfs = pcall(require, "lfs")
 local Json = require("miuread.json")
 local Config = require("miuread.config")
@@ -92,6 +93,186 @@ local function ipv4_tcp_factory()
     return conn
 end
 
+-- Connection reuse ----------------------------------------------------------
+-- socket.http and ssl.https open a fresh TCP+TLS connection for every request
+-- and close it again afterwards. One chapter needs four sequential requests to
+-- the same host, so on slow e-ink hardware the handshakes cost more than the
+-- transfers do. Both transports accept a `create` hook that supplies the
+-- connection object, which lets the socket from the previous request be handed
+-- back instead of a new one. This removes handshakes only: request pacing,
+-- ordering and the shared rate-limit budget are untouched.
+--
+-- Reuse is deliberately conservative. A socket returns to the pool only when
+-- the response carried a self-delimiting body, the peer did not ask for a
+-- close, and LuaSocket did not restart the exchange internally. Every other
+-- outcome closes the socket, which is exactly the previous behaviour.
+
+local KEEPALIVE_IDLE_SECONDS = 25
+local KEEPALIVE_MAX_REUSE = 64
+
+local function url_endpoint(url)
+    local scheme, authority = tostring(url or ""):match("^(https?)://([^/]+)")
+    if not scheme then return nil end
+    local host, port = authority:match("^(.-):(%d+)$")
+    host = host or authority
+    if host == "" then return nil end
+    return scheme, host:lower(), tonumber(port) or (scheme == "https" and 443 or 80)
+end
+
+-- ssl.https rewrites the request URL so the default port is explicit, which is
+-- what puts "host:443" in the Host header. Driving socket.http directly has to
+-- reproduce that, otherwise the request goes out subtly differently.
+local function explicit_port_url(url, port)
+    if not (ok_url and url_module and type(url_module.parse) == "function"
+        and type(url_module.build) == "function") then
+        return nil
+    end
+    local built, parsed = pcall(url_module.parse, url, {port = port})
+    if not built or type(parsed) ~= "table" then return nil end
+    local ok_build, value = pcall(url_module.build, parsed)
+    if not ok_build or type(value) ~= "string" or value == "" then return nil end
+    return value
+end
+
+local function apply_socket_timeouts(conn)
+    if not conn or type(conn.settimeout) ~= "function" then return end
+    pcall(conn.settimeout, conn, tonumber(socketutil.block_timeout) or 15, "b")
+    pcall(conn.settimeout, conn, tonumber(socketutil.total_timeout) or 35, "t")
+end
+
+-- A pooled socket the peer closed while it was idle becomes readable at once.
+-- Nothing is expected on an idle connection, so anything readable - a FIN or
+-- unread leftovers - means the socket cannot carry another request.
+local function connection_is_stale(conn)
+    if not conn then return true end
+    if not (ok_socket and socket and type(socket.select) == "function") then return false end
+    local called, readable = pcall(socket.select, {conn}, nil, 0)
+    if not called then return true end
+    return type(readable) == "table" and next(readable) ~= nil
+end
+
+local function open_connection(scheme, host, port, force_ipv4)
+    local previous_tcp
+    if force_ipv4 then
+        if not (ok_socket and socket and type(socket.tcp4) == "function") then
+            return nil, "IPv4 socket unavailable"
+        end
+        -- LuaSec builds its transport from socket.tcp, so the existing IPv4
+        -- override is the only way to reach the same family selection here.
+        previous_tcp = socket.tcp
+        socket.tcp = ipv4_tcp_factory
+    end
+
+    local conn, err
+    if scheme == "https" then
+        local factory_ok, factory = pcall(https.tcp, {})
+        if factory_ok and type(factory) == "function" then
+            local created, value = pcall(factory)
+            if created then conn = value else err = value end
+        else
+            err = factory_ok and "LuaSec create hook unavailable" or factory
+        end
+    elseif force_ipv4 then
+        conn, err = ipv4_tcp_factory()
+    else
+        local created, value = pcall(socket.tcp)
+        if created then conn = value else err = value end
+    end
+
+    if conn then
+        apply_socket_timeouts(conn)
+        local called, result, connect_error = pcall(conn.connect, conn, host, port)
+        if not called then
+            err = result
+        elseif result == nil then
+            err = connect_error or "connect failed"
+        end
+        if err then
+            pcall(conn.close, conn)
+            conn = nil
+        else
+            -- LuaSec swaps in the TLS socket during connect and only then
+            -- exposes its methods, so the timeouts have to be applied again.
+            apply_socket_timeouts(conn)
+        end
+    end
+
+    if previous_tcp then socket.tcp = previous_tcp end
+    if not conn then return nil, tostring(err or "connection failed") end
+    return conn
+end
+
+-- The object handed to socket.http through `create`. It looks like a socket to
+-- LuaSocket while keeping ownership of the underlying connection: close() only
+-- marks the exchange finished, and Http:_keepalive_finish decides afterwards
+-- whether the socket is clean enough to serve another request.
+local KeepaliveMethods = {}
+
+local Keepalive_mt = {
+    __index = function(session, key)
+        local method = KeepaliveMethods[key]
+        if method then return method end
+        local conn = rawget(session, "conn")
+        local target = conn and conn[key]
+        if type(target) ~= "function" then return nil end
+        return function(_, ...) return target(conn, ...) end
+    end,
+}
+
+function KeepaliveMethods:_drop()
+    local conn = rawget(self, "conn")
+    self.conn = nil
+    self.reused = false
+    if conn then pcall(conn.close, conn) end
+end
+
+function KeepaliveMethods:settimeout(...)
+    local conn = rawget(self, "conn")
+    if not conn or type(conn.settimeout) ~= "function" then return 1 end
+    return conn:settimeout(...)
+end
+
+function KeepaliveMethods:connect(host, port)
+    -- socket.http passes the port through from the parsed URL, where it is a
+    -- string. The pool compares it against a number, so normalise first.
+    port = tonumber(port) or port
+    self.hops = self.hops + 1
+    -- A second connect inside one request means LuaSocket restarted the
+    -- exchange for an internal redirect. It abandoned the previous response
+    -- without reading the body, so that socket can only be replaced.
+    if self.hops > 1 then self:_drop() end
+    if rawget(self, "conn") and not self.dirty and self.host == host and self.port == port then
+        apply_socket_timeouts(self.conn)
+        self.reused = true
+        return 1
+    end
+    self:_drop()
+    local conn, err = open_connection(self.scheme, host, port, self.force_ipv4)
+    if not conn then return nil, tostring(err) end
+    self.conn, self.host, self.port = conn, host, port
+    self.dirty, self.reused, self.uses = false, false, 0
+    return 1
+end
+
+function KeepaliveMethods:close()
+    self.dirty = true
+    return 1
+end
+
+function KeepaliveMethods:send(...)
+    local conn = rawget(self, "conn")
+    if not conn then return nil, "closed" end
+    return conn:send(...)
+end
+
+function KeepaliveMethods:receive(...)
+    local conn = rawget(self, "conn")
+    if not conn then return nil, "closed" end
+    local data, err, partial = conn:receive(...)
+    if data ~= nil or (partial ~= nil and #partial > 0) then self.received_any = true end
+    return data, err, partial
+end
+
 local function body_rate_limit(text)
     text = tostring(text or "")
     if text == "" or #text > 32768 or not text:match("^%s*[%[{]") then return nil end
@@ -130,12 +311,160 @@ function Http:new(store)
     }, self)
 end
 
+-- Instrumentation. The counters answer the only question an A/B download run
+-- needs: how much of the elapsed time was handshakes, transfers, or deliberate
+-- pacing, and how many connections the run actually had to open.
+function Http:_stats()
+    local stats = self.stats
+    if not stats then
+        stats = {
+            requests = 0, connections_opened = 0, connections_reused = 0,
+            network_seconds = 0, pacing_seconds = 0, rate_limit_seconds = 0,
+            bytes = 0,
+        }
+        self.stats = stats
+    end
+    return stats
+end
+
+function Http:stats_snapshot()
+    local copy = {}
+    for key, value in pairs(self:_stats()) do copy[key] = value end
+    return copy
+end
+
+function Http:_sleep_accounted(seconds, field)
+    seconds = tonumber(seconds) or 0
+    if seconds <= 0 then return end
+    local stats = self:_stats()
+    stats[field] = (stats[field] or 0) + seconds
+    pause(seconds)
+end
+
 function Http:set_download_network_policy(options)
     self.network_policy = NetworkPolicy:new(options or {})
     return self.network_policy
 end
 
-function Http:_transport_request(transport, request, force_ipv4)
+-- Hands out a reusable connection for `url`, taking the socket left over by
+-- the previous request to the same origin when one is still usable. Returns
+-- nil whenever reuse does not apply, which keeps the caller on the stock
+-- one-connection-per-request path.
+--
+-- Reuse is opt-in per request: only the download path passes keepalive=true.
+-- Login, shelf, progress, read-time and annotation requests are left on the
+-- original one-connection-per-request behaviour, so this optimisation cannot
+-- change how any of them talk to WeRead.
+function Http:_keepalive_begin(url, opt, force_ipv4, sink_path)
+    if Config.HTTP_KEEPALIVE == false then return nil end
+    if not (opt and opt.keepalive == true) then return nil end
+    -- Streaming downloads write straight into a file and are large enough that
+    -- the handshake is noise; leaving them out keeps the replay below simple.
+    if tostring(sink_path or "") ~= "" then return nil end
+    if not is_weread_url(url) then return nil end
+    local scheme, host, port = url_endpoint(url)
+    if not scheme then return nil end
+    -- ssl.https rejects a request table that already carries a create hook
+    -- ("create function not permitted"), so a reused TLS connection has to be
+    -- driven through socket.http directly. That is what ssl.https does
+    -- internally anyway: it only installs the TLS-aware create and forwards.
+    -- ssl.https.tcp builds exactly that connection, with LuaSec's own defaults,
+    -- so the TLS parameters stay identical to the non-pooled path.
+    local transport_url
+    if scheme == "https" then
+        local usable = ok_https and https and type(https.tcp) == "function"
+            and ok_http and http and type(http.request) == "function"
+        if usable then transport_url = explicit_port_url(url, port) end
+        if not transport_url then
+            if not self.keepalive_unavailable_logged then
+                self.keepalive_unavailable_logged = true
+                logger.warn("[MiuRead][HTTP] connection reuse unavailable for TLS",
+                    "luasec_tcp=", tostring(ok_https and https and type(https.tcp) == "function"),
+                    "socket_url=", tostring(ok_url and url_module ~= nil))
+            end
+            return nil
+        end
+    elseif not (ok_socket and socket and type(socket.tcp) == "function") then
+        return nil
+    end
+
+    force_ipv4 = force_ipv4 == true
+    local key = scheme .. "://" .. host .. (force_ipv4 and "#4" or "#a")
+    local pool = self.keepalive_pool
+    if not pool then pool = {}; self.keepalive_pool = pool end
+    local entry = pool[key]
+    pool[key] = nil
+    if entry and (clock_now() - (tonumber(entry.idle_since) or 0) > KEEPALIVE_IDLE_SECONDS
+        or connection_is_stale(entry.conn)) then
+        pcall(entry.conn.close, entry.conn)
+        entry = nil
+    end
+    return setmetatable({
+        scheme = scheme, force_ipv4 = force_ipv4, key = key,
+        conn = entry and entry.conn or nil,
+        host = entry and entry.host or nil,
+        port = entry and entry.port or port,
+        uses = entry and tonumber(entry.uses) or 0,
+        pooled = entry ~= nil,
+        transport_url = transport_url,
+        dirty = false, hops = 0, reused = false, received_any = false,
+    }, Keepalive_mt)
+end
+
+-- Decides after the exchange whether the socket may serve another request. The
+-- response must have been complete and self-delimiting, otherwise the next
+-- request would start reading in the middle of this one.
+function Http:_keepalive_finish(session, called, code, headers, status, stream_error)
+    if not session then return end
+    local conn = rawget(session, "conn")
+    if not conn then return end
+
+    local reusable = called == true and tonumber(code) ~= nil
+        and session.hops == 1 and not stream_error
+    if reusable then
+        local numeric = tonumber(code)
+        local version = tostring(status or ""):match("^HTTP/(%d+%.%d+)") or "1.1"
+        local connection = tostring(hget(headers, "connection") or ""):lower()
+        local encoding = tostring(hget(headers, "transfer-encoding") or ""):lower()
+        local delimited = hget(headers, "content-length") ~= nil
+            or encoding:find("chunked", 1, true) ~= nil
+            or numeric == 204 or numeric == 304
+        if connection:find("close", 1, true) then
+            reusable = false
+        elseif version == "1.0" and not connection:find("keep-alive", 1, true) then
+            reusable = false
+        elseif not delimited then
+            reusable = false
+        elseif session.uses + 1 >= KEEPALIVE_MAX_REUSE then
+            reusable = false
+        end
+    end
+    if not reusable then return session:_drop() end
+
+    session.uses = session.uses + 1
+    local pool = self.keepalive_pool
+    if not pool then pool = {}; self.keepalive_pool = pool end
+    -- Every download stage is serial, so one idle socket per origin is enough.
+    local previous = pool[session.key]
+    if previous and previous.conn ~= conn then pcall(previous.conn.close, previous.conn) end
+    pool[session.key] = {
+        conn = conn, host = session.host, port = session.port,
+        uses = session.uses, idle_since = clock_now(),
+    }
+    session.conn = nil
+end
+
+function Http:close_idle_connections()
+    local pool = self.keepalive_pool
+    if not pool then return end
+    self.keepalive_pool = {}
+    for _, entry in pairs(pool) do
+        if entry and entry.conn then pcall(entry.conn.close, entry.conn) end
+    end
+end
+
+function Http:_transport_request(transport, request, force_ipv4, keepalive)
+    if keepalive then request.create = function() return keepalive end end
     if force_ipv4~=true then return pcall(transport.request, request) end
     if not (ok_socket and socket and type(socket.tcp4)=="function") then
         logger.warn("[MiuRead][NetworkPolicy] IPv4-only socket unavailable; keeping automatic networking")
@@ -216,6 +545,9 @@ function Http:_observe_download_network(url, delay, code)
 end
 
 function Http:probe_download_recovery()
+    -- This runs only after the route was lost, so nothing in the pool can have
+    -- survived. Drop the sockets before probing rather than reusing a dead one.
+    self:close_idle_connections()
     local policy=self.network_policy
     local base=probe_origin(self.last_request_url) or "https://weread.qq.com/"
     local mode=policy and policy:current_mode() or "auto"
@@ -379,6 +711,9 @@ function Http:_report_rate_limit(remaining, attempt, maximum, code)
 end
 
 function Http:_wait_rate_limit(seconds, attempt, maximum, code)
+    -- A cooldown outlasts any server-side keep-alive window, so the pooled
+    -- sockets are certain to be dead by the time the wait ends.
+    self:close_idle_connections()
     seconds = math.max(1, math.floor(tonumber(seconds) or 1))
     local deadline = clock_now() + seconds
     self.rate_limit_until = math.max(tonumber(self.rate_limit_until) or 0, deadline)
@@ -391,7 +726,7 @@ function Http:_wait_rate_limit(seconds, attempt, maximum, code)
             self:_report_rate_limit(remaining, attempt, maximum, code)
             last_report = remaining
         end
-        pause(math.min(1, remaining))
+        self:_sleep_accounted(math.min(1, remaining), "rate_limit_seconds")
     end
 end
 
@@ -404,13 +739,13 @@ function Http:_pace(url, opt)
     local wait = math.max(0, (tonumber(self.rate_limit_until) or 0) - now)
     local interval = tonumber(opt.min_interval) or tonumber(self.min_weread_interval) or 0
     wait = math.max(wait, interval - (now - scoped_last))
-    if wait > 0 then pause(wait) end
+    if wait > 0 then self:_sleep_accounted(wait, "pacing_seconds") end
     if self:_cancelled() then error("download cancelled") end
     if opt.shared_pacing==true then
         local shared_wait=self:_reserve_shared_pacing(scope,interval,opt.pacing_jitter)
-        if shared_wait>0 then pause(shared_wait) end
+        if shared_wait>0 then self:_sleep_accounted(shared_wait, "pacing_seconds") end
     elseif tonumber(opt.pacing_jitter or 0)>0 then
-        pause(math.random()*tonumber(opt.pacing_jitter))
+        self:_sleep_accounted(math.random()*tonumber(opt.pacing_jitter), "pacing_seconds")
     end
     if self:_cancelled() then error("download cancelled") end
     local requested_at=clock_now()
@@ -589,14 +924,54 @@ function Http:_request_once(opt)
             return 1
         end
         local force_ipv4=self.network_policy and self.network_policy:should_force_ipv4() or false
-        local called, ok, code, resp_headers, status = self:_transport_request(transport, {
-            url = current,
-            method = method,
-            headers = headers,
-            source = body and ltn12.source.string(body) or nil,
-            sink = sink,
-        }, force_ipv4)
+        local keepalive=self:_keepalive_begin(current,opt,force_ipv4,sink_path)
+        local request_url,request_port=current,nil
+        if keepalive and keepalive.scheme=="https" then
+            -- ssl.https would refuse the create hook, so drive socket.http with
+            -- the URL and port ssl.https would have produced for it.
+            transport=http
+            request_url=keepalive.transport_url
+            request_port=keepalive.port
+        end
+        headers["Connection"]=keepalive and "keep-alive" or nil
+        local called, ok, code, resp_headers, status
+        local transport_started=clock_now()
+        for attempt = 1, 2 do
+            called, ok, code, resp_headers, status = self:_transport_request(transport, {
+                url = request_url,
+                port = request_port,
+                method = method,
+                headers = headers,
+                source = body and ltn12.source.string(body) or nil,
+                sink = sink,
+            }, force_ipv4, keepalive)
+            if attempt > 1 or (called and tonumber(code)) then break end
+            -- A pooled socket the peer closed between requests fails before the
+            -- response starts. Nothing was delivered, so replaying a read is
+            -- safe. Writes are never replayed here: a POST whose pooled socket
+            -- died is reported upwards and left to the caller's own retry,
+            -- which starts from a fresh connection because a failed exchange is
+            -- never returned to the pool.
+            local replayable = keepalive ~= nil and keepalive.reused == true
+                and keepalive.received_any ~= true and total_bytes == 0
+                and (method == "GET" or method == "HEAD")
+            if not replayable then break end
+            logger.info("[MiuRead][HTTP] reused connection closed by peer; retrying on a new socket",
+                "url=", Util.redact_url(current))
+            keepalive:_drop()
+            keepalive.hops, keepalive.pooled = 0, false
+            chunks, first_data_at = {}, nil
+        end
         local request_finished=clock_now()
+        local stats=self:_stats()
+        stats.requests=stats.requests+1
+        stats.network_seconds=stats.network_seconds+math.max(0,request_finished-transport_started)
+        stats.bytes=stats.bytes+total_bytes
+        if keepalive and keepalive.reused==true then
+            stats.connections_reused=stats.connections_reused+1
+        else
+            stats.connections_opened=stats.connections_opened+1
+        end
         if stream_file then
             local flushed,flush_error=stream_file:flush()
             stream_file:close()
@@ -607,6 +982,7 @@ function Http:_request_once(opt)
             pcall(opt.on_chunk,total_bytes,current)
         end
         socketutil:reset_timeout()
+        self:_keepalive_finish(keepalive,called,code,resp_headers,status,stream_error)
         local text = sink_path~="" and table.concat(preview) or table.concat(chunks)
         if stream_error then return text,nil,resp_headers,current,tostring(stream_error) end
         if not called then return text, nil, resp_headers, current, tostring(ok) end

--- a/miuread.koplugin/miuread/reader.lua
+++ b/miuread.koplugin/miuread/reader.lua
@@ -874,9 +874,10 @@ function Reader:check_login_session()
     return result
 end
 
-local function load_reader_context(self,book_id,chapter_uid,require_psvts)
+local function load_reader_context(self,book_id,chapter_uid,require_psvts,keepalive)
     local url=Protocol.is_mp(book_id) and Protocol.mp_reader_url(book_id) or Protocol.reader_url(book_id,chapter_uid)
-    local html,_,final_url=self.http:download(url,{headers={Accept="text/html,application/xhtml+xml"},retries=2})
+    local html,_,final_url=self.http:download(url,{headers={Accept="text/html,application/xhtml+xml"},retries=2,
+        keepalive=keepalive==true})
     local page_error=login_page_error(html,final_url)
     if page_error then error(page_error) end
     local context=regex_context(html)
@@ -906,8 +907,10 @@ local function load_reader_context(self,book_id,chapter_uid,require_psvts)
     return context
 end
 
-function Reader:state(book_id,chapter_uid)
-    return load_reader_context(self,book_id,chapter_uid,true)
+-- `keepalive` is set only by the download task, which issues this request and
+-- the four chapter shards back to back against the same origin.
+function Reader:state(book_id,chapter_uid,keepalive)
+    return load_reader_context(self,book_id,chapter_uid,true,keepalive)
 end
 
 function Reader:catalog(book_id, request_options)
@@ -920,6 +923,7 @@ function Reader:catalog(book_id, request_options)
         local http_options={
             headers={Origin=BASE, Referer=Protocol.reader_url(book_id)},
             retries=1, timeout={10,22},
+            keepalive=request_options.keepalive==true,
         }
         if type(request_options.on_retry)=="function" then http_options.on_retry=request_options.on_retry end
         local data = self.http:post_json(BASE .. "/web/book/chapterInfos", {bookIds={tostring(book_id)}},http_options)
@@ -951,11 +955,12 @@ function Reader:catalog(book_id, request_options)
     error(result)
 end
 
-function Reader:shard(path, book_id, chapter_uid, psvts, style)
+function Reader:shard(path, book_id, chapter_uid, psvts, style, keepalive)
     local body = Protocol.content_fields(book_id, chapter_uid, psvts, style)
     local raw, code = self.http:request{
         url=BASE .. path, method="POST", body=Json.encode(body), retries=3,
         headers={Origin=BASE, Referer=Protocol.reader_url(book_id, chapter_uid), ["Content-Type"]="application/json;charset=UTF-8"},
+        keepalive=keepalive==true,
     }
     if code < 200 or code >= 300 then error(path .. " failed: HTTP " .. tostring(code)) end
     local auth_error = raw_service_auth_error(raw)
@@ -968,9 +973,9 @@ function Reader:_txt_once(book, chapter, opt, state)
     opt = opt or {}
     local id = tostring(book.bookId or book.book_id)
     local uid = chapter.chapterUid or chapter.uid
-    state = state or self:state(id, uid)
-    local a = self:shard("/web/book/chapter/t_0", id, uid, state.psvts, false)
-    local ok_b, b = pcall(self.shard, self, "/web/book/chapter/t_1", id, uid, state.psvts, false)
+    state = state or self:state(id, uid, opt.keepalive)
+    local a = self:shard("/web/book/chapter/t_0", id, uid, state.psvts, false, opt.keepalive)
+    local ok_b, b = pcall(self.shard, self, "/web/book/chapter/t_1", id, uid, state.psvts, false, opt.keepalive)
     if not ok_b then b = "" end
     local xhtml = Codec.text_xhtml(Codec.decode_parts({a, b}))
     if not has_readable_content(xhtml, false) then error("decoded TXT chapter is empty") end
@@ -986,14 +991,14 @@ function Reader:_epub_once(book, chapter, opt, state)
     opt = opt or {}
     local id = tostring(book.bookId or book.book_id)
     local uid = chapter.chapterUid or chapter.uid
-    state = state or self:state(id, uid)
+    state = state or self:state(id, uid, opt.keepalive)
 
-    local a = self:shard("/web/book/chapter/e_0", id, uid, state.psvts, false)
+    local a = self:shard("/web/book/chapter/e_0", id, uid, state.psvts, false, opt.keepalive)
     if a:match("^%s*{") and a:find('"bookId"', 1, true) then
         return self:_txt_once(book, chapter, opt, state)
     end
-    local b = self:shard("/web/book/chapter/e_1", id, uid, state.psvts, false)
-    local c = self:shard("/web/book/chapter/e_3", id, uid, state.psvts, false)
+    local b = self:shard("/web/book/chapter/e_1", id, uid, state.psvts, false, opt.keepalive)
+    local c = self:shard("/web/book/chapter/e_3", id, uid, state.psvts, false, opt.keepalive)
     local xhtml = Codec.decode_parts({a, b, c})
     -- Keep the exact decrypted XHTML before image localization, body extraction
     -- or any MiuRead rewrite. This is the missing reference required to compare
@@ -1004,7 +1009,7 @@ function Reader:_epub_once(book, chapter, opt, state)
     state.coord_html = AnnotationCoord.fromDownloadedXhtml(xhtml)
 
     local css = "body{line-height:1.7;margin:5%;}img{max-width:100%;height:auto;}"
-    local ok_style, style_raw = pcall(self.shard, self, "/web/book/chapter/e_2", id, uid, state.psvts, true)
+    local ok_style, style_raw = pcall(self.shard, self, "/web/book/chapter/e_2", id, uid, state.psvts, true, opt.keepalive)
     if ok_style and not style_raw:match("^%s*{") then
         local ok, value = pcall(Codec.decode_parts, {style_raw})
         if ok and value ~= "" then css = value end
@@ -1116,7 +1121,7 @@ function Reader:_chapter_once(book, chapter, format, opt)
     opt = opt or {}
     local id = tostring(book.bookId or book.book_id)
     local uid = chapter.chapterUid or chapter.uid
-    local state = self:state(id, uid)
+    local state = self:state(id, uid, opt.keepalive)
 
     if format == "txt" then
         local ok, a, b, c, d = pcall(self._txt_once, self, book, chapter, opt, state)


### PR DESCRIPTION
每一章正文要向同一台服务器发四次请求，而 socket.http / ssl.https 每次都重新建立 TCP+TLS 再关掉。真机实测每个请求约 3.3 秒，其中绝大部分是握手和往返，与传输量无关——没有图片的章节四次请求要 13 秒，正文却只有十几 kB。

改为通过两个传输层都支持的 create hook，把上一次请求的 socket 交还给下一次。请求节奏、顺序和限流预算一律不变，只是不再重复握手。

复用条件保持保守：响应必须自带定界（content-length / chunked / 204 / 304）、对端没有要求 close、且 LuaSocket 没有内部重启过交换，否则一律关闭连接，行为与改动前一致。空闲 25 秒过期，单连接上限 64 次请求，取用前用socket.select 探测陈旧连接；限流冷却和网络恢复探测前主动清空连接池。对端在空闲期间关闭连接时透明重放一次，写请求只在确认请求没发出去时才重放。

ssl.https 会拒绝带 create 的请求表（create function not permitted），因此 带池的 TLS 请求直接驱动 socket.http，连接仍由 ssl.https.tcp 构建，TLS 参 数与原路径完全一致；同时复现 ssl.https 对 URL 补写默认端口的处理，保证
Host 头不变。

同时给下载任务加一条汇总日志，用于验证和以后定位：

  [MiuRead][Download] run summary ... elapsed= network= pacing= throttle=
  requests= connections= reused= bytes=

Kindle Oasis 2 实测，同一本书（36 章）、同一构建，仅切换开关：

  关闭：elapsed 962.0s  network 887.9s  272 请求  272 连接
  开启：elapsed 729.1s  network 665.6s  257 请求   79 连接（178 次复用）

即每次省下的握手约 1.25 秒。按请求数归一化后可归因于本改动的约 173 秒
（基线那次在第 31 章还额外踩了一次图片下载失败重试）。

汇总数据同时否定了另外两个猜测：pacing 为 0，min_weread_interval 的 0.45 秒间隔从未真正触发，因为请求本身就比它慢；本地处理加上让路节流合计不到
运行时间的 8%。

剩余的 79 条连接基本都是流式落盘的图片和 tar 包，本次未纳入复用。
Config.HTTP_KEEPALIVE 置 false 可完全回退到原有行为。

真机测试crash log：
关闭链接复用：08/29/26-01:58:03 INFO  [MiuRead][Download] run summary book= 3300192100 title= 这世界既残酷也温柔 keepalive= false chapters= 36 fetched= 36 checkpoint= 0 elapsed=962.0s network=887.9s pacing=0.0s ratelimit=0.0s throttle=7.7s requests= 272 connections= 272 reused= 0 bytes= 28.0MB 
开启链接复用：08/29/26-02:21:21 INFO  [MiuRead][Download] run summary book= 3300192100 title= 这世界既残酷也温柔 keepalive= true chapters= 36 fetched= 36 checkpoint= 0 elapsed=729.1s network=665.6s pacing=0.0s ratelimit=0.0s throttle=7.7s requests= 257 connections= 79 reused= 178 bytes= 27.5MB 