### PR TITLE
fix: Kindle 下载期间阻止自动休眠

### DIFF
--- a/miuread.koplugin/miuread/download_task.lua
+++ b/miuread.koplugin/miuread/download_task.lua
@@ -72,6 +72,7 @@ function DownloadTask:new(store)
         hibernated = nil,
         poll_task = nil,
         standby_held = false,
+        last_device_timeout_reset_at = 0,
         keep_awake_enabled = true,
         backgrounded = false,
         pause_reasons = {},
@@ -114,11 +115,7 @@ end
 function DownloadTask:set_backgrounded(value)
     self.backgrounded = value == true
     if self.hibernated then self.hibernated.backgrounded=self.backgrounded end
-    -- beta.9 never keeps the normal Home surface awake just because a download
-    -- exists. The lock is acquired only after the physical Suspend lifecycle
-    -- has entered DOWNLOAD_LOCKED; this lets Home auto-sleep normally and then
-    -- continue the same worker behind the lock screen.
-    if background_lock_mode(self.power_mode) and not self:is_paused() then
+    if self.job and not self:is_paused() then
         self:_hold_awake()
     else
         self:_release_awake()
@@ -800,15 +797,30 @@ end
 
 function DownloadTask:_lockscreen_keepalive_allowed()
     return self.keep_awake_enabled == true
-        and background_lock_mode(self.power_mode)
+        and self.job ~= nil
+        and not self:is_paused()
 end
 
 function DownloadTask:_reset_device_timeout()
     if not self:_lockscreen_keepalive_allowed() then return false end
     if device_is("Kindle") then
-        -- Kindle workers do not touch T1 or powerd. A true result only
-        -- means the screen-saver hold session is still owned by the controller.
-        return PseudoLockscreen.active() == true
+        if PseudoLockscreen.active() == true then return true end
+        local now=os.time()
+        -- Kindle's own implementation warns that this should be requested no
+        -- more often than every five minutes. Four minutes leaves margin before
+        -- the normal inactivity timeout without hammering powerd.
+        if now-tonumber(self.last_device_timeout_reset_at or 0)<240 then
+            return true
+        end
+        local powerd = Device and Device.powerd
+        if not powerd or type(powerd.resetT1Timeout) ~= "function" then return false end
+        local ok, err = pcall(powerd.resetT1Timeout, powerd)
+        if ok then
+            self.last_device_timeout_reset_at=now
+        else
+            logger.warn("[MiuRead][DownloadTask] device timeout reset failed", tostring(err))
+        end
+        return ok
     end
     local powerd = Device and Device.powerd
     if powerd and type(powerd.resetT1Timeout) == "function" then
@@ -843,22 +855,18 @@ function DownloadTask:_hold_awake()
         self:_release_awake()
         return false
     end
-    if device_is("Kindle") and PseudoLockscreen.active()~=true then
-        self:_release_awake()
-        return false
-    end
     if PseudoLockscreen.active()==true then
-        local stale=self.standby_held or SuspendWorkLease.has("download")
+        local stale=self.standby_held == true
         self.standby_held=false
-        SuspendWorkLease.release("download")
+        if stale then SuspendWorkLease.release_download() end
         local alive=self:_reset_device_timeout()
         if stale then
             logger.info("[MiuRead][DownloadTask] worker power claim released; controller owns background")
         end
         return alive==true or (not device_is("Kindle") and SuspendWorkLease.has("pseudo_lockscreen"))
     end
-    if self.standby_held and SuspendWorkLease.has("download") then return true end
-    local ok = SuspendWorkLease.acquire("download")
+    if self.standby_held then return true end
+    local ok = SuspendWorkLease.acquire_download()
     if ok then
         self.standby_held = true
         local reset = self:_reset_device_timeout()
@@ -871,9 +879,9 @@ function DownloadTask:_hold_awake()
 end
 
 function DownloadTask:_release_awake()
-    local held = self.standby_held or SuspendWorkLease.has("download")
+    local held = self.standby_held == true
     self.standby_held = false
-    SuspendWorkLease.release("download")
+    if held then SuspendWorkLease.release_download() end
     if held then logger.info("[MiuRead][DownloadTask] standby lease released") end
 end
 

--- a/miuread.koplugin/miuread/suspend_work_lease.lua
+++ b/miuread.koplugin/miuread/suspend_work_lease.lua
@@ -60,6 +60,32 @@ local function copy_reasons(value)
     return out
 end
 
+function M.acquire_download()
+    if not is_kindle() then return M.acquire("download") end
+    local value = shared()
+    value.download_count = math.max(0, tonumber(value.download_count) or 0)
+    value.download_count = value.download_count + 1
+    logger.info("[MiuRead][SuspendLease] Kindle download wake acquired",
+        "count=", tostring(value.download_count))
+    return true, M.snapshot()
+end
+
+function M.release_download()
+    if not is_kindle() then return M.release("download") end
+    local value = shared()
+    value.download_count = math.max(0, tonumber(value.download_count) or 0)
+    if value.download_count == 0 then return true, M.snapshot() end
+    value.download_count = value.download_count - 1
+    logger.info("[MiuRead][SuspendLease] Kindle download wake released",
+        "count=", tostring(value.download_count))
+    return true, M.snapshot()
+end
+
+function M.download_active()
+    if not is_kindle() then return M.has("download") end
+    return math.max(0, tonumber(shared().download_count) or 0) > 0
+end
+
 function M.acquire(reason)
     reason = tostring(reason or "background")
     local value = shared()
@@ -140,6 +166,7 @@ function M.clear(reason)
     local value = shared()
     local count = reason_count(value)
     value.reasons = {}
+    value.download_count = 0
     value.generation = value.generation + 1
     value.changed_at = os.time()
     if value.held then


### PR DESCRIPTION
> [!WARNING]
> 当前提交只适用于旧的 beta.3/beta.4 下载电源路径，**不要原样合入 5.8.0-beta.9**。GitHub 的 `CLEAN / MERGEABLE` 只表示没有文本冲突；实际合并会撤销 beta.9 的 Kindle 后台下载设计。

## beta.9 适配审查（2026-09-06）

beta.9 已把原问题改为新的生命周期模型：普通 Home 下载不主动阻止系统进入锁屏；真实 Suspend 到来后，插件先确认任务可后台继续，再进入 `SCREEN_SAVER_HOLD` / `DOWNLOAD_LOCKED`，由后台控制器持有设备状态并继续 worker。

当前 PR 合入 beta.9 后会反向修改这些行为：

- 下载任务只要存在且未暂停，就在普通 Home 阶段持有下载租约。
- Kindle 未进入伪锁屏时重新每 240 秒调用 `resetT1Timeout()`。
- 新增的 Kindle 下载计数租约只服务于上述旧路径。

这与 beta.9 `download_task.lua` 中“普通 Home 允许正常自动锁屏、Kindle worker 不直接触碰 T1/powerd”的实现和注释相反。因此分支暂不变基、不推送旧补丁。

KPW6 已部署 `5.8.0-beta.9`（不含本 PR）验证。2026-09-06 的真机结果：

- 下载在普通 Home 启动后正常前进。
- 设备自动进入 `SCREEN_SAVER_HOLD`，日志报告 `download_continue=true`、`early download suspend lock prepared=true`。
- 锁屏后章节从 90 继续到至少 115/361，心跳从 121 继续到至少 365。
- 10 秒采样中 `powerd` CPU tick 为 `235 → 235`，`preventScreenSaver=0`，没有旧失败方案的忙循环。
- 完整的 361 章下载经历多轮锁屏后持续运行；网络停滞触发 fail-open 后，worker 从 checkpoint 重启并在网络恢复后从第 222 章附近继续。
- 09:59:15 已缓存 `361/361`，随后完成 5,180,011 字节 EPUB 打包并安装，主页下载卡片到 100%。
- 下载任务、owner 和临时状态随后清除；10:03:53 设备正常进入 `REAL_SUSPEND`，日志为 `download=false`、`no_task`、`pseudo_lock=false`、`leases=none`。

因此本 PR 关闭为已被 beta.9 上游实现取代，真机长下载、异常恢复、完成清理和休眠恢复均已闭环。如果后续出现可复现的 beta.9 失败，可以重新打开本 PR，只根据失败日志提交最小修复，不恢复旧的前台 T1 续期方案。

## 原问题

Kindle 上的旧版下载任务只有进入锁屏后台模式后才会持有电源状态；停留在下载页或切换到觅阅其他页面时，系统仍可能按普通空闲流程休眠并中断下载。

## 原修改（仅旧版本）

- 下载任务存在且未暂停时启用 Kindle 下载专用计数租约。
- 使用 KOReader 已有的 `resetT1Timeout()` 延后自动休眠，并限制为最多每 4 分钟调用一次。
- 最后一个任务完成、失败、取消或暂停时释放计数租约。
- 进入原有伪锁屏后台流程时，将电源控制继续交给原有锁屏控制器。
- 不修改 `preventScreenSaver`、全局休眠时间、启动项或其他插件功能。

## 旧版真机验证

- 设备：Kindle Paperwhite 6（KPW6）
- 固件：5.17.1.0.4
- 觅阅：5.8.0-beta.3
- 前台下载和切换到其他觅阅页面后，下载心跳与章节进度持续前进。
- 跨过 4 分钟 T1 续期点后仍继续下载，没有自动休眠或界面卡死。
- 大书下载成功后任务所有者清除、计数恢复为 0，随后设备可正常自动休眠并唤醒。
- 下载期间与结束后 `powerd` 均无异常 CPU 或日志增长。
