### PR TITLE
下载书籍每章加载一次网页版阅读器页面改为每4分钟加载一次，整本下载耗时下降约五分之一，下载流量减少72%

### DIFF
--- a/miuread.koplugin/miuread/downloader.lua
+++ b/miuread.koplugin/miuread/downloader.lua
@@ -595,6 +595,7 @@ local function cache_save_base(cache, chapter, coord_body, body, style, assets, 
     if state and (state.psvts or state.pclts or state.token or state.url) then
         cache.manifest.session = {
             psvts=state.psvts, pclts=state.pclts, token=state.token,
+            context_fetched_at=tonumber(state.context_fetched_at),
             book_version=tonumber(state.book_version
                 or (type(state.book)=="table" and
                     (state.book.version or state.book.bookVersion or state.book.book_version))),
@@ -1169,7 +1170,12 @@ function Downloader:_save(book, chapters, assets, css, cover, opt, failures, ses
             -- library[bookId].catalog above. Duplicating the full map in
             -- sessions caused #91's settings file to grow past Lua's parser
             -- nesting limit on long books.
-            reader_url=session.url, context_updated_at=os.time(),
+            -- Stamp when the reader page was loaded, not when the download
+            -- finished. psvts is reused across chapters, so these can be
+            -- minutes apart, and the workers reading this field decide from it
+            -- whether the context still signs a valid request.
+            reader_url=session.url,
+            context_updated_at=tonumber(session.context_fetched_at) or os.time(),
             app_id=Protocol.app_id(Protocol.USER_AGENT),
         })
     end

--- a/miuread.koplugin/miuread/reader.lua
+++ b/miuread.koplugin/miuread/reader.lua
@@ -780,7 +780,8 @@ local function response_header(headers, name)
 end
 
 function Reader:new(http, store)
-    return setmetatable({http=http, store=store, _renewing_session=false, _transient_image_roots={}}, self)
+    return setmetatable({http=http, store=store, _renewing_session=false,
+        _transient_image_roots={}, _reader_context=nil}, self)
 end
 
 function Reader:cleanup_transient_images()
@@ -859,6 +860,9 @@ function Reader:_recover_login_session()
 
     self._renewing_session = false
     if ok then
+        -- A renewed session invalidates the page load the cached psvts came
+        -- from, so the next chapter must fetch a reader page again.
+        self:forget_reader_context("login renewed")
         logger.info("[MiuRead][Reader] login renewal completed; web credentials present",
             "skills=", tostring(result.skills_verified == true),
             "vid_unchanged=", tostring(before_vid == "" or before_vid == tostring(result.vid or "")))
@@ -874,8 +878,24 @@ function Reader:check_login_session()
     return result
 end
 
+local function reader_page_url(book_id,chapter_uid)
+    if Protocol.is_mp(book_id) then return Protocol.mp_reader_url(book_id) end
+    return Protocol.reader_url(book_id,chapter_uid)
+end
+
+-- How long one reader-page load stays usable. `psvts` identifies a page load,
+-- not a chapter, so the same value signs every chapter's content request.
+--
+-- The content API stops accepting a psvts 300 seconds after its page loaded.
+-- Measured on a 108-chapter download: two chapters answered with an empty body
+-- at 303 s and 303 s of context age, and both returned full content on the
+-- retry that reloaded the page. Note that sync.lua reuses a context for 15
+-- minutes -- the reading-time endpoint is more tolerant than this one, so that
+-- value must not be copied here. Refresh with a margin below the real limit.
+local READER_CONTEXT_MAX_AGE = 240
+
 local function load_reader_context(self,book_id,chapter_uid,require_psvts,keepalive)
-    local url=Protocol.is_mp(book_id) and Protocol.mp_reader_url(book_id) or Protocol.reader_url(book_id,chapter_uid)
+    local url=reader_page_url(book_id,chapter_uid)
     local html,_,final_url=self.http:download(url,{headers={Accept="text/html,application/xhtml+xml"},retries=2,
         keepalive=keepalive==true})
     local page_error=login_page_error(html,final_url)
@@ -911,6 +931,53 @@ end
 -- the four chapter shards back to back against the same origin.
 function Reader:state(book_id,chapter_uid,keepalive)
     return load_reader_context(self,book_id,chapter_uid,true,keepalive)
+end
+
+-- Everything a reader page contributes that belongs to the book rather than to
+-- one chapter. `source` (the whole decoded page bootstrap) is deliberately left
+-- out: nothing outside load_reader_context reads it, and keeping it would pin
+-- the page's entire JSON tree in memory for the length of a download.
+local function book_scoped_context(context)
+    return {
+        psvts=context.psvts, pclts=context.pclts, token=context.token,
+        book=context.book, book_version=context.book_version,
+    }
+end
+
+function Reader:forget_reader_context(reason)
+    if not self._reader_context then return false end
+    logger.info("[MiuRead][Reader] reader context dropped","reason=",tostring(reason or ""))
+    self._reader_context=nil
+    return true
+end
+
+-- The per-chapter state table. _epub_once and _txt_once use this table as their
+-- working area -- they write raw_xhtml, coord_html, image_work_root and the
+-- image_archive_* flags into it -- so every chapter must receive its own table.
+-- Only the book-scoped fields are shared, and `url` is rebuilt locally for the
+-- requested chapter instead of being carried over from the cached page.
+function Reader:chapter_state(book_id,chapter_uid,keepalive)
+    local cached=self._reader_context
+    local usable=cached and tostring(cached.book_id)==tostring(book_id)
+        and os.time()-(tonumber(cached.fetched_at) or 0) < READER_CONTEXT_MAX_AGE
+        and optional_value(cached.context.psvts)
+    if not usable then
+        self._reader_context={
+            book_id=tostring(book_id),
+            context=book_scoped_context(self:state(book_id,chapter_uid,keepalive)),
+            fetched_at=os.time(),
+        }
+        cached=self._reader_context
+    end
+    local state={}
+    for key,value in pairs(cached.context) do state[key]=value end
+    state.url=reader_page_url(book_id,chapter_uid)
+    -- When the page was actually loaded, not when this chapter asked for it.
+    -- The download record carries psvts forward to the reading-time and
+    -- progress workers, which decide from this stamp whether to reload; a
+    -- cached context must not be able to present itself as newly fetched.
+    state.context_fetched_at=cached.fetched_at
+    return state
 end
 
 function Reader:catalog(book_id, request_options)
@@ -973,7 +1040,7 @@ function Reader:_txt_once(book, chapter, opt, state)
     opt = opt or {}
     local id = tostring(book.bookId or book.book_id)
     local uid = chapter.chapterUid or chapter.uid
-    state = state or self:state(id, uid, opt.keepalive)
+    state = state or self:chapter_state(id, uid, opt.keepalive)
     local a = self:shard("/web/book/chapter/t_0", id, uid, state.psvts, false, opt.keepalive)
     local ok_b, b = pcall(self.shard, self, "/web/book/chapter/t_1", id, uid, state.psvts, false, opt.keepalive)
     if not ok_b then b = "" end
@@ -991,7 +1058,7 @@ function Reader:_epub_once(book, chapter, opt, state)
     opt = opt or {}
     local id = tostring(book.bookId or book.book_id)
     local uid = chapter.chapterUid or chapter.uid
-    state = state or self:state(id, uid, opt.keepalive)
+    state = state or self:chapter_state(id, uid, opt.keepalive)
 
     local a = self:shard("/web/book/chapter/e_0", id, uid, state.psvts, false, opt.keepalive)
     if a:match("^%s*{") and a:find('"bookId"', 1, true) then
@@ -1121,7 +1188,7 @@ function Reader:_chapter_once(book, chapter, format, opt)
     opt = opt or {}
     local id = tostring(book.bookId or book.book_id)
     local uid = chapter.chapterUid or chapter.uid
-    local state = self:state(id, uid, opt.keepalive)
+    local state = self:chapter_state(id, uid, opt.keepalive)
 
     if format == "txt" then
         local ok, a, b, c, d = pcall(self._txt_once, self, book, chapter, opt, state)
@@ -1154,6 +1221,12 @@ function Reader:chapter(book, chapter, format, opt)
         local ok, a, b, c, d = pcall(self._chapter_once, self, book, chapter, format, opt)
         if ok then return a, b, c, d end
         last = a
+        -- Any failure may be the cached reader context's fault: a stale psvts
+        -- makes the content API answer with an empty body, and three of those
+        -- would silently turn a real chapter into a blank structure page. Drop
+        -- it so the next attempt loads a fresh page, which is what every
+        -- attempt did before the context was cached.
+        self:forget_reader_context("chapter attempt failed")
         local control_error=tostring(a or "")
         if control_error:find("__MIUREAD_HIBERNATE__",1,true)
             or control_error:lower():find("download cancelled",1,true) then

--- a/tools/test_reader_context.lua
+++ b/tools/test_reader_context.lua
@@ -1,0 +1,182 @@
+local TOOL_DIR=tostring(arg and arg[0] or ''):match('^(.*)/[^/]+$') or '.'
+local ROOT=TOOL_DIR..'/../miuread.koplugin/'
+package.path=ROOT..'?.lua;'..package.path
+
+package.preload['logger']=function() return {info=function() end,warn=function() end,err=function() end,dbg=function() end} end
+package.preload['socket']=function() return {gettime=function() return os.time() end} end
+package.preload['lfs']=function() return {} end
+package.preload['libs/libkoreader-lfs']=function() return {attributes=function() return nil end,mkdir=function() return true end} end
+package.preload['miuread.codec']=function() return {} end
+-- reader.lua pulls miuread.http in only for these four classifiers; loading the
+-- real module would drag the whole LuaSocket stack into this test.
+package.preload['miuread.http']=function()
+    return {
+        is_auth_error=function(v) return tostring(v or ''):find('MiuReadAuth',1,true)~=nil end,
+        is_rate_limit_error=function() return false end,
+        is_network_error=function() return false end,
+        auth_error_message=function(code,message)
+            return '[MiuReadAuth] error_code='..tostring(code)..': '..tostring(message or '')
+        end,
+    }
+end
+package.preload['miuread.annotation_coord']=function()
+    return {fromDownloadedXhtml=function(v) return tostring(v or '') end}
+end
+
+-- window.__INITIAL_STATE__ is the only reason the reader page is fetched at
+-- all, so the decoder has to be real enough to reach the fields inside it.
+local function json_decode(text)
+    local pos=1
+    local function skip() pos=text:find('[^ \t\r\n]',pos) or (#text+1) end
+    local value
+    local function str()
+        pos=pos+1
+        local out={}
+        while true do
+            local c=text:sub(pos,pos)
+            if c=='' or c=='"' then pos=pos+1 break end
+            if c=='\\' then out[#out+1]=text:sub(pos+1,pos+1); pos=pos+2
+            else out[#out+1]=c; pos=pos+1 end
+        end
+        return table.concat(out)
+    end
+    function value()
+        skip()
+        local c=text:sub(pos,pos)
+        if c=='{' or c=='[' then
+            local object=c=='{'
+            local out={}
+            pos=pos+1; skip()
+            if text:sub(pos,pos)==(object and '}' or ']') then pos=pos+1 return out end
+            while true do
+                if object then
+                    skip()
+                    local key=str()
+                    skip(); pos=pos+1
+                    out[key]=value()
+                else
+                    out[#out+1]=value()
+                end
+                skip()
+                local separator=text:sub(pos,pos); pos=pos+1
+                if separator~=',' then break end
+            end
+            return out
+        elseif c=='"' then return str()
+        elseif text:sub(pos,pos+3)=='true' then pos=pos+4 return true
+        elseif text:sub(pos,pos+4)=='false' then pos=pos+5 return false
+        elseif text:sub(pos,pos+3)=='null' then pos=pos+4 return nil
+        end
+        local literal=text:match('^%-?%d+%.?%d*',pos) or ''
+        pos=pos+#literal
+        return tonumber(literal)
+    end
+    return value()
+end
+package.preload['miuread.json']=function()
+    return {encode=function() return '{}' end,decode=json_decode}
+end
+
+local Reader=require('miuread.reader')
+local Protocol=require('miuread.protocol')
+
+local PAGE='<html><script>window.__INITIAL_STATE__ = {"reader":{"psvts":"ps1",'
+    ..'"pclts":"pc1","token":"tok1"},"bookInfo":{"bookId":"B1","version":7}}</script></html>'
+
+local fetches
+local function new_reader(body)
+    fetches={}
+    local http={}
+    function http:download(url,opt)
+        fetches[#fetches+1]={url=url,keepalive=opt and opt.keepalive}
+        return body or PAGE,{},url
+    end
+    return Reader:new(http,{})
+end
+
+-- One reader page serves every chapter of a book.
+local r=new_reader()
+local first=r:chapter_state('B1','c1',true)
+local second=r:chapter_state('B1','c2',true)
+local third=r:chapter_state('B1','c3',true)
+assert(#fetches==1,'a cached reader context still refetched the page')
+assert(first.psvts=='ps1' and third.psvts=='ps1','psvts did not reach every chapter')
+assert(fetches[1].keepalive==true,'the reader page stopped opting into connection reuse')
+assert(third.token=='tok1' and third.pclts=='pc1','token/pclts were dropped from the cache')
+assert(third.book_version==7,'book_version was dropped from the cache')
+
+-- _epub_once and _txt_once use the state table as their per-chapter working
+-- area. Sharing one table would carry a chapter's body, its coordinate source
+-- and its image directory into the next chapter.
+assert(second~=third,'chapters shared a single state table')
+second.raw_xhtml='body'; second.coord_html='coords'; second.image_work_root='/tmp/ch2'
+second.image_archive_expected=true; second.structural=true
+local fourth=r:chapter_state('B1','c4',true)
+assert(fourth.raw_xhtml==nil and fourth.coord_html==nil,'chapter body/coordinates leaked forward')
+assert(fourth.image_work_root==nil,'image work directory leaked forward')
+assert(fourth.image_archive_expected==nil and fourth.structural==nil,'chapter flags leaked forward')
+assert(fourth.source==nil,'the decoded page bootstrap is pinned for the whole run')
+
+-- The download record carries psvts to the reading-time and progress workers,
+-- which decide from its timestamp whether to reload the page. A cached context
+-- must report when its page loaded, never when this chapter asked for it.
+local loaded_at=r._reader_context.fetched_at
+r._reader_context.fetched_at=loaded_at-100
+local later=r:chapter_state('B1','c5',true)
+assert(#fetches==1,'the 100 s old context should still have been served')
+assert(later.context_fetched_at==loaded_at-100,'a cached context claimed to be newly fetched')
+r._reader_context.fetched_at=loaded_at
+
+-- The reader URL is the image Referer, so it must name the current chapter.
+assert(second.url==Protocol.reader_url('B1','c2'),'a cached url was reused for another chapter')
+assert(third.url==Protocol.reader_url('B1','c3'),'the url was not rebuilt per chapter')
+
+-- Book identity and freshness.
+r:chapter_state('B2','c1',true)
+assert(#fetches==2,'a different book reused another book context')
+r=new_reader()
+r:chapter_state('B1','c1',true)
+-- The content API rejects a psvts 300 s after its page loaded, so the context
+-- must be refreshed with a margin below that, never at sync.lua's 15 minutes.
+r._reader_context.fetched_at=os.time()-241
+r:chapter_state('B1','c2',true)
+assert(#fetches==2,'an expired reader context was reused')
+r._reader_context.fetched_at=os.time()-235
+r:chapter_state('B1','c3',true)
+assert(#fetches==2,'a fresh reader context was discarded')
+r._reader_context.fetched_at=os.time()-299
+r:chapter_state('B1','c4',true)
+assert(#fetches==3,'a context close to the 300 s server limit was still served')
+
+-- A page without psvts must still fail loudly rather than sign requests blank.
+local blank=new_reader('<html>{"pclts":"pc1","token":"tok1"}</html>')
+assert(not pcall(blank.chapter_state,blank,'B1','c1',true),'a page without psvts was accepted')
+
+-- A renewed session invalidates the page load the psvts came from.
+r=new_reader()
+r.store={auth=function() return {login_session_id='s1',auth_revision=0,
+    account={vid='v1'},cookies={wr_vid='v1',wr_skey='k1'}} end,save_auth=function() return true end}
+function r.http:post_json() return {succ=1},{},{} end
+r:chapter_state('B1','c1',true)
+assert(r:_recover_login_session()==true,'the stubbed renewal did not succeed')
+assert(r._reader_context==nil,'a renewed session kept the old reader context')
+
+-- Every retry must reload the page. A stale psvts answers with an empty body,
+-- and three of those make Reader:chapter convert a real chapter into a blank
+-- structure page, so a retry that reuses the same context corrupts silently.
+r=new_reader()
+r:chapter_state('B1','c1',true)
+local attempts=0
+r._chapter_once=function(self)
+    attempts=attempts+1
+    if attempts>1 then
+        assert(self._reader_context==nil,'a chapter retry reused the failed context')
+    end
+    self:chapter_state('B1','c1',true)
+    error('decoded EPUB chapter is empty')
+end
+pcall(r.chapter,r,{bookId='B1'},{chapterUid='c1'},'epub',{})
+assert(attempts==3,'the chapter was not retried three times')
+assert(#fetches==3,'the retries did not each load their own reader page')
+
+print('reader context reuse: PASS')


### PR DESCRIPTION
下载每章书籍之前都要完整拉一次网页版阅读器页面，只为取出 psvts——它是正文接口的 ps 字段并参与签名计算，缺了服务端不认。于是每章五个请求：网页版阅读器页面加四个正文分片。而阅读页面平均 232KB，是整个下载里最大的响应体。

但 psvts 跟章节无关，它只标识“某次打开了阅读页”，有效期为5分钟。5分钟以内每章都能用同一个值签名。这不是新结论。sync.lua 早就这么用了，它取这份上下文时 chapter_uid 直接传nil。downloader自己也一直在把 psvts 存进断点（cache.manifest.session），只是存完就没再用过。

改动就是把它缓存下来，每章复用。但缓存的那个表不能直接交给下一章。_epub_once 和 _txt_once 会往表里写当前章
节的东西：正文（raw_xhtml）、批注坐标基准（coord_html）、图片临时目录（image_work_root）等等。几章共用一个表的话，上一章的坐标基准会被当成下一章的用——这种错不报错，只会让划线位置全错。所以每章都从缓存浅拷贝一个新表。url 也每章本地重算，因为它要当图片下载的Referer。

psvts缓存在三种情况下将被丢弃：TTL 到期、登录续期成功、以及任何一次章节尝试失败。

Kindle Oasis 2 实测，三体全集 108 章，同一构建仅切换本改动：

  改动前：elapsed 1128.1s  network 866.0s  608 请求  32.9MB
  改动后：elapsed  918.1s  network 721.9s  504 请求   9.3MB

108 次阅读页加载减到 4 次。省下的时间来自请求数而不是流量：每请求平均耗时
几乎没变（1.424s → 1.432s），网络时间降幅 16.6% 与请求数降幅 17.1% 一致。

新增 tools/test_reader_context.lua。