### PR TITLE
fix: 减少主页、评论与退出阅读卡顿，修复刷新及导航保存边界

### DIFF
--- a/miuread.koplugin/main.lua
+++ b/miuread.koplugin/main.lua
@@ -1224,7 +1224,19 @@ function Plugin:_shelf_covers_enabled(prefs)
     return enabled
 end
 function Plugin:safe(label,fn) return function(...) local a={...}; local ok,e=xpcall(function() return fn(unpack_args(a)) end,debug.traceback); if not ok then logger.err("[MiuRead]",label,e); self:info(_("Operation failed")..":\n"..U.first_line(e)) end end end
-function Plugin:is_online() local ok,N=pcall(require,"ui/network/manager"); if not ok or not N or not N.isOnline then return true end; local g,v=pcall(N.isOnline,N); return not g or v==true end
+function Plugin:is_online()
+    local ok, network = pcall(require, "ui/network/manager")
+    if not ok or not network then return true end
+    -- UI preflight checks only the local link. isOnline performs synchronous
+    -- DNS; actual reachability is checked by the request's async worker.
+    for _, name in ipairs({"isWifiOn", "isConnected"}) do
+        if type(network[name]) == "function" then
+            local called, value = pcall(network[name], network)
+            if called and value == false then return false end
+        end
+    end
+    return true
+end
 -- Fast local hint for lifecycle paths. Never call NetworkManager:isOnline() from
 -- ReaderReady/close/Suspend: on some Kindle network states that synchronous
 -- probe can stall the UI thread for many seconds. false means the Wi-Fi radio
@@ -3417,6 +3429,8 @@ function Plugin:_save_home_preferences_deferred(home,preferences,delay)
     else
         return self:_save_home_preferences(home,preferences)
     end
+    self._home_state_save_on_exit=delay==false
+        and (self._home_state_save_pending~=true or self._home_state_save_on_exit==true)
     self._home_state_save_pending=true
     self._home_state_save_generation=(tonumber(self._home_state_save_generation) or 0)+1
     local generation=self._home_state_save_generation
@@ -3424,6 +3438,9 @@ function Plugin:_save_home_preferences_deferred(home,preferences,delay)
         UIManager:unschedule(self._home_state_save_task)
         self._home_state_save_task=nil
     end
+    -- Tab/page navigation stays in memory until an existing lifecycle flush.
+    -- A full settings write here blocks the next tap for seconds on Kindle.
+    if self._home_state_save_on_exit then return end
     local task
     task=function()
         if generation~=self._home_state_save_generation or not self._home_state_save_pending then
@@ -3431,8 +3448,7 @@ function Plugin:_save_home_preferences_deferred(home,preferences,delay)
             return
         end
         self._home_state_save_task=nil
-        self._home_state_save_pending=false
-        local saved,err=self.store:flush()
+        local saved,err=self:_flush_home_preferences()
         if saved==true then
             logger.info("[MiuRead][HomeState] preferences saved after idle")
         else
@@ -3456,6 +3472,7 @@ function Plugin:_pause_home_preferences_flush(reason)
 end
 
 function Plugin:_resume_home_preferences_flush(delay)
+    if self._home_state_save_on_exit then return false end
     if not self._home_state_save_pending or self._home_state_save_task then return false end
     self._home_state_save_generation=(tonumber(self._home_state_save_generation) or 0)+1
     local generation=self._home_state_save_generation
@@ -3470,8 +3487,7 @@ function Plugin:_resume_home_preferences_flush(delay)
             return
         end
         self._home_state_save_task=nil
-        self._home_state_save_pending=false
-        local saved,err=self.store:flush()
+        local saved,err=self:_flush_home_preferences()
         if saved==true then
             logger.info("[MiuRead][HomeState] deferred preferences saved after home idle")
         else
@@ -3490,13 +3506,18 @@ function Plugin:_flush_home_preferences()
         UIManager:unschedule(self._home_state_save_task)
         self._home_state_save_task=nil
     end
-    self._home_state_save_pending=false
+    local preferences=self.store:preferences()
     local saved,err=self.store:flush()
     if saved~=true then
+        -- Store may reload the last good disk snapshot on failure. Keep the
+        -- pending preferences in memory so the next save can retry them.
+        self.store:save_preferences_deferred(preferences)
         logger.warn("[MiuRead][HomeState] preferences save failed before leaving home",U.first_line(err or "unknown",160))
         return false,err
     end
-    logger.info("[MiuRead][HomeState] preferences saved before leaving home")
+    self._home_state_save_pending=false
+    self._home_state_save_on_exit=false
+    logger.info("[MiuRead][HomeState] preferences saved")
     return true
 end
 
@@ -4058,7 +4079,7 @@ function Plugin:_home_schedule_device_state_probe(delay)
         end
         local started=monotonic_wall_time()
         local ok,err=self.device_state_async:run("home-device-state",function()
-            return require("miuread.home_data").quick_device_state(true)
+            return require("miuread.home_data").quick_device_state(true, true)
         end,function(result)
             if generation~=self._home_device_probe_generation then return end
             local elapsed=math.floor((monotonic_wall_time()-started)*1000+.5)
@@ -4765,6 +4786,7 @@ function Plugin:_home_manual_refresh()
         return true
     end
     if active=="device" then
+        if self._home_state_save_pending and not self:_flush_home_preferences() then return false end
         self.store:reload(); self.store:prune_missing_files()
         local root=LocalLibrary.normalize(self:_home_root())
         if root=="" then
@@ -4802,6 +4824,7 @@ function Plugin:_home_refresh_whole_page()
 end
 
 function Plugin:_home_complete_refresh(confirmed)
+    if self._home_state_save_pending and not self:_flush_home_preferences() then return false end
     UnifiedLibrary.invalidate_external_cache()
     self:_home_reset_local_metadata()
     self.store:reload()
@@ -4936,7 +4959,7 @@ function Plugin:_home_change_page(delta)
     self._home_page_changed_at=Time.now()
     self:_home_cancel_visible_page_work("home page changed")
     self:_home_bump_interaction_generation()
-    self:_save_home_preferences_deferred(home,preferences)
+    self:_save_home_preferences_deferred(home,preferences,false)
     local applied=self:_home_apply_section(section)
     logger.info("[MiuRead][HomePageSwitch]","section=",tostring(section),"from=",tostring(current),"to=",tostring(target),"network=false")
     return applied
@@ -4957,7 +4980,7 @@ function Plugin:_home_apply_section(section)
         local current,preferences=self:_home_preferences()
         current.page_by_section=type(current.page_by_section)=="table" and current.page_by_section or {}
         current.page_by_section[section]=page
-        self:_save_home_preferences_deferred(current,preferences)
+        self:_save_home_preferences_deferred(current,preferences,false)
     end
     -- Keep the "visible work" target in sync with the page that is actually
     -- on screen. beta.23 could continue preparing covers from the previous page
@@ -5006,6 +5029,7 @@ function Plugin:_home_apply_section(section)
 end
 
 function Plugin:_set_home_section(section)
+    local started=monotonic_wall_time()
     local allowed={}
     for _,key in ipairs(self._home_visible_keys or HOME_SECTION_ORDER) do allowed[key]=true end
     section=allowed[section] and section or (self._home_visible_keys and self._home_visible_keys[1]) or "shelf"
@@ -5015,9 +5039,10 @@ function Plugin:_set_home_section(section)
     self._home_page_changed_at=Time.now()
     self:_home_cancel_visible_page_work("home section changed")
     self:_home_bump_interaction_generation()
-    self:_save_home_preferences_deferred(home,preferences)
+    self:_save_home_preferences_deferred(home,preferences,false)
     if self:_home_apply_section(section) then
-        logger.info("[MiuRead][HomeSectionSwitch]","to=",tostring(section),"network=false")
+        logger.info("[MiuRead][HomeSectionSwitch]","to=",tostring(section),"network=false",
+            "elapsed_ms=",tostring(math.floor((monotonic_wall_time()-started)*1000+.5)))
     else
         self:_refresh_home_view(nil,"section")
     end
@@ -25812,7 +25837,13 @@ function Plugin:_thought_favorite_context(info)
     local book_id=tostring(info.book_id or "")
     local chapter_uid=tostring(info.chapter_uid or "")
     local book=self.store and self.store:book(book_id) or nil
-    local current=self:_current_book_record()
+    -- Opening comments only needs metadata from the active document, not a
+    -- settings reload and backup. A document change still takes the full path.
+    local current=self:_reader_session_is_weread() and self.sync and self.sync.current or nil
+    if not current or type(current.path)~="string" or current.path==""
+        or current.path~=self.sync:_document_path() then
+        current=self:_current_book_record()
+    end
     if current and current.book and tostring(current.book.book_id or current.book.bookId or "")==book_id then
         book=current.book
     end
@@ -28905,6 +28936,7 @@ function Plugin:onSuspend()
     -- visible widget is preserved; normal Home downloads do not own a standby
     -- lease until this Suspend lifecycle has already committed.
     if HomeView.is_shown() and not self:_active_reader_ui() then
+        if self._home_state_save_on_exit then self:_flush_home_preferences() end
         self:_home_freeze_for_suspend()
     end
     if self._download_resume_task then
@@ -28983,6 +29015,7 @@ function Plugin:onResume()
             "time=ignored","progress=ignored","annotations=ignored")
         return
     end
+    require("miuread.subprocess_hygiene").reset_resolver()
     -- Kindle ScreenSaver Hold gets the strict wake boundary introduced in
     -- beta.10. Kobo keeps its already-validated legacy lifecycle unchanged.
     if PseudoLockscreen.device_platform()=="kindle" then

--- a/miuread.koplugin/main.lua
+++ b/miuread.koplugin/main.lua
@@ -3425,7 +3425,7 @@ function Plugin:_save_home_preferences_deferred(home,preferences,delay)
     preferences=preferences or self.store:preferences()
     preferences.home_ui=home
     if self.store.save_preferences_deferred then
-        self.store:save_preferences_deferred(preferences)
+        self.store:save_preferences_deferred(preferences,delay==false)
     else
         return self:_save_home_preferences(home,preferences)
     end
@@ -11943,15 +11943,17 @@ function Plugin:_home_full_refresh(confirmed)
         UIManager:show(dialog)
         return true
     end
-    local listener=self:_koreader_device_listener()
+    -- Home callbacks may still belong to the closed Reader plugin. Its device
+    -- listener updates ReaderFooter before repainting, which needs a document.
+    local reader=self:_active_reader_ui()
+    local listener=reader and reader.document and reader.devicelistener
     if listener and type(listener.onFullRefresh)=="function" then
         local ok,err=pcall(listener.onFullRefresh,listener)
         if ok then return true end
         logger.warn("[MiuRead][Refresh] native full refresh failed",tostring(err))
     end
-    -- Compatibility fallback for KOReader builds where the active UI listener
-    -- is temporarily unavailable during a desktop transition.
-    UIManager:broadcastEvent(Event:new("FullRefresh"))
+    -- This is the native full-refresh operation without the Reader-only footer.
+    UIManager:setDirty(nil,"full")
     return true
 end
 
@@ -17550,6 +17552,11 @@ function Plugin:_request_reader_close(generation,source)
     if local_session then
         logger.info("[MiuRead][ReaderClose] local close command returned",
             "generation=",tostring(generation))
+    end
+    -- onClose has returned after saving/releasing the document. Restore the
+    -- parked Home before due background callbacks can block its next UI tick.
+    if self:_reader_lifecycle_state()=="closed" and HomeView.is_shown() then
+        return self:_finish_reader_return(generation,"reader close completed")
     end
     self:_schedule_reader_return_finish(generation,.10,"close requested")
     return true

--- a/miuread.koplugin/miuread/extension_job.lua
+++ b/miuread.koplugin/miuread/extension_job.lua
@@ -130,10 +130,7 @@ local function network_connected()
         if ok then connected=value==true end
     end
     if connected==false then return false end
-    if type(NetworkMgr.isOnline)=="function" then
-        local ok,value=pcall(NetworkMgr.isOnline,NetworkMgr)
-        if ok then return connected~=false and value==true end
-    end
+    -- This gate runs on UI timers; the worker checks Internet reachability.
     if connected~=nil then return connected==true end
     if type(NetworkMgr.isWifiOn)=="function" then
         local ok,value=pcall(NetworkMgr.isWifiOn,NetworkMgr)

--- a/miuread.koplugin/miuread/home_data.lua
+++ b/miuread.koplugin/miuread/home_data.lua
@@ -561,7 +561,7 @@ function HomeData.quick_power_state(force)
     return power
 end
 
-function HomeData.quick_device_state(force)
+function HomeData.quick_device_state(force, probe_online)
     local now = os.time()
     if not force and device_cache and now - device_cache.at < 60 then
         return device_cache.value
@@ -583,7 +583,7 @@ function HomeData.quick_device_state(force)
             local ok, value = pcall(network.isConnected, network)
             if ok then state.connected = value == true end
         end
-        if state.connected ~= false and type(network.isOnline) == "function" then
+        if probe_online and state.connected ~= false and type(network.isOnline) == "function" then
             local ok, online = pcall(network.isOnline, network)
             if ok then state.online = online == true end
         elseif state.connected == false then
@@ -598,7 +598,17 @@ function HomeData.quick_device_state(force)
         end
     end
 
+    if probe_online and state.online == true then
+        NetworkHealth.note_success("network-manager")
+    end
     local health = NetworkHealth.snapshot()
+    if not probe_online and state.connected ~= false then
+        if health.state == "ok" and health.age <= 60 and health.reason ~= "network-manager-associated" then
+            state.online = true
+        elseif health.state == "down" and health.age <= 20 then
+            state.online = false
+        end
+    end
     if state.wifi_on == false then
         state.network_phase = "off"
     else
@@ -614,7 +624,6 @@ function HomeData.quick_device_state(force)
             -- state. Do not leave Home stuck on “恢复中” after Reader/network
             -- manager already sees the active network. Internet reachability is
             -- still represented separately by state.online.
-            NetworkHealth.note_success("network-manager-associated")
             state.network_phase = "connected"
         elseif health.state == "recovering" and health.age <= 50 then
             state.network_phase = "recovering"

--- a/miuread.koplugin/miuread/read_report_service.lua
+++ b/miuread.koplugin/miuread/read_report_service.lua
@@ -2,6 +2,7 @@ local Json = require("miuread.json")
 local U = require("miuread.util")
 local Adapter = require("miuread.legacy_adapter_worker")
 local Config = require("miuread.config")
+local SubprocessHygiene = require("miuread.subprocess_hygiene")
 
 local Service = {}
 
@@ -343,6 +344,7 @@ function Service.run(job)
             out.writer_barrier_seq=tonumber(control.writer_barrier_seq or 0) or 0
             local uncertain = result.uncertain == true or tostring(result.error_kind or "") == "unconfirmed"
             local kind = result.accepted and nil or (uncertain and "unconfirmed" or classify_error(result.error_kind,result.error))
+            if kind == "transport" then SubprocessHygiene.reset_resolver() end
             if result.accepted then
                 consecutive_failures = 0
                 consecutive_unconfirmed = 0
@@ -409,6 +411,7 @@ function Service.run(job)
         consecutive_failures = consecutive_failures + 1
         consecutive_unconfirmed = 0
         local kind=classify_error(nil,result)
+        if kind == "transport" then SubprocessHygiene.reset_resolver() end
         blocked = kind == "authentication"
         local delay = retry_delay(kind, consecutive_failures, interval)
         local due = final_flush and 0 or (completed_at + delay)
@@ -523,6 +526,7 @@ function Service.run(job)
                         -- counted or replayed.
                         next_due = now + first_delay
                         last_report_at = now
+                        SubprocessHygiene.reset_resolver()
                     end
                     write_context()
                     write_service_status({
@@ -580,6 +584,7 @@ function Service.run(job)
                     local now = os.time()
                     last_report_at = now
                     next_due = now + first_delay
+                    SubprocessHygiene.reset_resolver()
                 end
             end
 

--- a/miuread.koplugin/miuread/store.lua
+++ b/miuread.koplugin/miuread/store.lua
@@ -262,12 +262,48 @@ local function invalidate_upload_health_table(auth)
     end
     return auth
 end
+-- Ordinary settings use the same literals as dump(), without indentation.
+-- Unusual values/keys or cycles retain the existing serializer fallback.
+local function compact_settings(data)
+    local out,active={},{}
+    local function append(value)
+        local kind=type(value)
+        if kind=="table" then
+            if active[value] then return false end
+            active[value]=true
+            out[#out+1]="{"
+            for key,item in pairs(value) do
+                local key_type=type(key)
+                if key_type~="string" and key_type~="number" and key_type~="boolean" then return false end
+                out[#out+1]="["
+                if not append(key) then return false end
+                out[#out+1]="]="
+                if not append(item) then return false end
+                out[#out+1]=","
+            end
+            out[#out+1]="}"
+            active[value]=nil
+        elseif kind=="string" then
+            out[#out+1]=string.format("%q",value)
+        elseif kind=="number" or kind=="boolean" or kind=="nil" then
+            out[#out+1]=tostring(value)
+        else
+            return false
+        end
+        return true
+    end
+    if not append(data) then return nil end
+    return table.concat(out)
+end
+
 local function settings_payload(data,path)
     -- Match KOReader LuaSettings:flush(): settings files are executable Lua
     -- chunks that must return the serialized table. dump() itself only emits
     -- the table expression, so writing it directly would create an invalid
     -- settings file beginning with "{".
-    return "-- "..tostring(path or "").."\nreturn "..dump(data,nil,true).."\n"
+    -- Key ordering has no persistence semantics, but sorting large catalogs on
+    -- every progress update blocks the foreground reader/Home event loop.
+    return "-- "..tostring(path or "").."\nreturn "..(compact_settings(data) or dump(data)).."\n"
 end
 
 local function settings_payload_valid(payload)
@@ -1307,7 +1343,10 @@ function Store:clear_account_shelf_cache()
 end
 function Store:preferences() return U.merge(defaults.preferences,self:get("preferences",{})) end
 function Store:save_preferences(v) return self:set("preferences",U.merge(defaults.preferences,v or {})) end
-function Store:save_preferences_deferred(v) self:set_deferred("preferences",U.merge(defaults.preferences,v or {})) end
+function Store:save_preferences_deferred(v,preserve_home_navigation)
+    self:set_deferred("preferences",U.merge(defaults.preferences,v or {}))
+    if preserve_home_navigation==true then self._pending_home_navigation=true end
+end
 function Store:books_root() local p=self:preferences().download_dir; if p=="" then p=self.default_books_dir end; U.mkdir(p); return p end
 function Store:epub_root() return self:books_root() end
 function Store:prefetch_book_path(id) return self.prefetch_dir.."/"..U.id_name(id) end
@@ -2267,11 +2306,47 @@ local function merge_newer_progress_sessions(memory_sessions,disk_sessions)
     return memory_sessions
 end
 
+local function pending_home_navigation(store)
+    local prefs=store.db.data.preferences
+    local home=type(prefs)=="table" and prefs.home_ui
+    if not store._pending_home_navigation or type(home)~="table" then return nil end
+    return {active_section=home.active_section,page_by_section=U.copy(home.page_by_section)}
+end
+
+local function restore_home_navigation(store,navigation)
+    if not navigation then return end
+    local prefs=store.db.data.preferences
+    if type(prefs)~="table" then prefs={}; store.db.data.preferences=prefs end
+    if type(prefs.home_ui)~="table" then prefs.home_ui={} end
+    prefs.home_ui.active_section=navigation.active_section
+    prefs.home_ui.page_by_section=navigation.page_by_section
+end
+
+local function settings_equal(a,b,seen)
+    if a==b then return true end
+    -- dump() persists numbers through tostring(), whose precision can be lower
+    -- than an in-memory reading ratio. Compare the representation we can save.
+    if type(a)=="number" and type(b)=="number" then return tostring(a)==tostring(b) end
+    if type(a)~="table" or type(b)~="table" then return false end
+    seen=seen or {}
+    if seen[a]==b then return true end
+    seen[a]=b
+    for key,value in pairs(a) do
+        if not settings_equal(value,b[key],seen) then return false end
+    end
+    for key in pairs(b) do
+        if a[key]==nil then return false end
+    end
+    return true
+end
+
 function Store:flush(reason)
     local flush_started=store_perf_clock()
     reason=tostring(reason or "direct")
+    local navigation=pending_home_navigation(self)
+    local disk_data
     if not self.isolated then
-        local disk_data=settings_file_data(self.settings_path)
+        disk_data=settings_file_data(self.settings_path)
         if type(disk_data)=="table" then
             self.db.data.sessions=merge_newer_progress_sessions(self.db.data.sessions,disk_data.sessions)
         end
@@ -2289,10 +2364,17 @@ function Store:flush(reason)
                 "fields_removed=",tostring(removed))
         end
     end
+    -- Compare with the freshly read file, not a cached dirty flag: callers may
+    -- mutate nested settings and detached workers may advance progress on disk.
+    if disk_data and settings_equal(self.db.data,disk_data) then
+        self._pending_home_navigation=nil
+        logger.info("[MiuRead][StorePerf] settings unchanged","reason=",reason,
+            "elapsed_ms=",tostring(math.floor((store_perf_clock()-flush_started)*1000+0.5)))
+        return true
+    end
     local previous_path=self.settings_path..".previous"
     if not self.isolated then
-        local valid=settings_file_valid(self.settings_path)
-        if valid then U.copy_file(self.settings_path,previous_path) end
+        if disk_data then U.copy_file(self.settings_path,previous_path) end
     end
 
     -- Serialize exactly like KOReader LuaSettings:flush(): dump() emits only a
@@ -2320,6 +2402,7 @@ function Store:flush(reason)
         if not self.isolated then restore_settings_file(self.settings_path,self.settings_backup_path) end
         local disk_ok=settings_file_valid(self.settings_path)
         if disk_ok then self.db=LuaSettings:open(self.settings_path) end
+        restore_home_navigation(self,navigation)
         logger.warn("[MiuRead][StorePerf] full settings flush failed",
             "reason=",reason,"elapsed_ms=",tostring(math.floor((store_perf_clock()-flush_started)*1000+0.5)),
             "error=",tostring(err or "unknown"))
@@ -2332,6 +2415,7 @@ function Store:flush(reason)
         if not self.isolated then restore_settings_file(self.settings_path,self.settings_backup_path) end
         local disk_ok=settings_file_valid(self.settings_path)
         if disk_ok then self.db=LuaSettings:open(self.settings_path) end
+        restore_home_navigation(self,navigation)
         logger.warn("[MiuRead][StorePerf] full settings flush failed",
             "reason=",reason,"elapsed_ms=",tostring(math.floor((store_perf_clock()-flush_started)*1000+0.5)),
             "error=",tostring(validation_reason or "validation_failed"))
@@ -2344,6 +2428,7 @@ function Store:flush(reason)
         end
         os.remove(previous_path)
     end
+    self._pending_home_navigation=nil
     logger.info("[MiuRead][StorePerf] full settings flush",
         "reason=",reason,
         "elapsed_ms=",tostring(math.floor((store_perf_clock()-flush_started)*1000+0.5)),
@@ -2351,8 +2436,12 @@ function Store:flush(reason)
     return true
 end
 function Store:reload()
+    local navigation=pending_home_navigation(self)
     if not self.isolated then restore_settings_file(self.settings_path,self.settings_backup_path) end
     self.db = LuaSettings:open(self.settings_path)
+    -- Reload fresh worker results without discarding deferred tab/page choices.
+    -- Only navigation is overlaid; all other settings and library data reload.
+    restore_home_navigation(self,navigation)
     if not self.isolated then
         local valid=settings_file_valid(self.settings_path)
         if valid then U.copy_file(self.settings_path,self.settings_backup_path) end

--- a/miuread.koplugin/miuread/subprocess_hygiene.lua
+++ b/miuread.koplugin/miuread/subprocess_hygiene.lua
@@ -1,5 +1,15 @@
 local M = {}
 
+function M.reset_resolver()
+    local ok, ffi = pcall(require, "ffi")
+    if not ok or not ffi then return false end
+    -- glibc retains resolver sockets/configuration across fork and suspend.
+    -- Other platforms may not export this symbol; leave their resolver alone.
+    pcall(ffi.cdef, "int __res_init(void);")
+    local called, result = pcall(function() return ffi.C.__res_init() end)
+    return called and result == 0
+end
+
 local function inherited_fd_target(ffi, fd)
     local path = "/proc/self/fd/" .. tostring(fd)
     local buffer = ffi.new("char[?]", 512)
@@ -12,6 +22,9 @@ local function inherited_fd_target(ffi, fd)
 end
 
 function M.close_inherited_sockets()
+    -- Release libc-owned sockets before the generic descriptor sweep, so its
+    -- next lookup cannot reuse a descriptor that now belongs to another file.
+    M.reset_resolver()
     local ok_ffi, ffi = pcall(require, "ffi")
     if not ok_ffi or not ffi then return false, "ffi_unavailable", 0 end
     local ok_lfs, lfs = pcall(require, "libs/libkoreader-lfs")

--- a/tools/kpw6_regressions/README.md
+++ b/tools/kpw6_regressions/README.md
@@ -39,3 +39,57 @@ and real fork tests do not prove stability after a long real deep-sleep cycle.
 Navigation positions remain in memory until a lifecycle save or another settings
 write; an abnormal process exit can lose the latest tab/page selection. Reading
 progress persistence is unchanged.
+
+## Reader return follow-up (2026-09-12)
+
+`full_refresh_test.lua <plugin>/main.lua` checks Home with a closed Reader,
+active Reader footer refresh, a closing Reader, and listener failure fallback.
+`../test_store_shared.lua` also covers unchanged close saves, nested mutations,
+deletions, malformed disk repair, newer externally verified progress and write
+failure recovery. Run `../test_store_repair.lua` for compaction/recovery checks.
+
+On a KPW6 using a private copy of the actual 2.8 MB settings file on `/mnt/us`,
+three changed-save samples fell from 1872–1908 ms to 1041–1097 ms; three unchanged
+saves fell from 1845–1872 ms to 159–251 ms. Every saved value was compared after
+loading the output. These isolated save timings do not measure end-to-end Home
+return or physical e-ink refresh. All settings writes remain synchronous;
+serialization order alone changes, and unchanged saves compare against a fresh
+validated disk read after merging newer progress and applying compaction.
+
+## Combined optimization review follow-up
+
+Deferred Home navigation is now marked in the shared Store. A reload overlays
+only the pending active tab and per-tab pages onto the newly loaded preferences;
+worker library/progress data and unrelated settings still come from disk. A
+successful save (including an unchanged save) clears the overlay. Failed writes
+retain it for retry. Opening downloads or receiving a background result therefore
+does not reset the current navigation or require an extra foreground save.
+
+Regression coverage includes worker-result reloads, unrelated disk preferences,
+nested mutations/deletions, decimal round trips, failure/reload/retry and overlay
+release after both changed and unchanged saves. The combined review passed 292
+static checks and 14 device test scripts. The live fork/DNS script could not
+complete because host lookup failed; a fresh LuaSocket process without MiuRead
+also failed the same lookup. This is a blocked live-network check, not a pass.
+
+## Small follow-up for remaining return latency
+
+Settings now use the same Lua literals/number formatting as KOReader dump with
+compact whitespace; cycles, unusual keys and unsupported values fall back to the
+existing serializer. Loading, validation, atomic replacement, backups and pending
+navigation handling remain in place. On the same device/settings copy, three
+changed saves measured 1008–1097 ms before and 727–779 ms after, with full value
+round-trip comparison; file size fell from about 2.8 MB to 1.2 MB.
+
+When native ReaderUI:onClose has returned and the reader is fully gone with a
+parked Home available, restoration runs immediately through the existing guarded
+completion path. Incomplete/failed closes and missing Home retain the old settle
+and recovery path. This avoids due background callbacks getting ahead of the
+Home restoration timer; it does not skip document saving or close cleanup.
+
+`compact_settings_test.lua <plugin>/miuread/store.lua` covers escaping, sparse
+keys, booleans, aliases and native fallback. `reader_return_test.lua
+<plugin>/main.lua` covers completed/unfinished/failed close, missing Home and
+stale generations. This round passed all 17 device scripts, including live fork
+DNS, plus 292 static checks. Save benchmarks exclude UI/physical display time;
+end-to-end targets still require real interaction samples.

--- a/tools/kpw6_regressions/README.md
+++ b/tools/kpw6_regressions/README.md
@@ -1,0 +1,41 @@
+# KPW6 UI and resume regressions
+
+These tests cover UI network preflight, resolver recovery, report timing across
+suspend, Home preference persistence, and popup metadata reuse. Fixtures do not
+contain accounts, reading history, or device settings. Like actions are mocked.
+
+Copy the repository to `/tmp/miuread-reviewed` on a KOReader device, then run from
+the KOReader directory (where `setupkoenv.lua` and `luajit` are available):
+
+```sh
+./luajit /tmp/miuread-reviewed/tools/kpw6_regressions/network_test.lua /tmp/miuread-reviewed/miuread.koplugin
+./luajit /tmp/miuread-reviewed/tools/kpw6_regressions/service_test.lua /tmp/miuread-reviewed/miuread.koplugin
+./luajit /tmp/miuread-reviewed/tools/kpw6_regressions/fork_test.lua /tmp/miuread-reviewed/miuread.koplugin
+./luajit /tmp/miuread-reviewed/tools/kpw6_regressions/navigation_test.lua /tmp/miuread-reviewed/miuread.koplugin/main.lua
+./luajit /tmp/miuread-reviewed/tools/kpw6_regressions/popup_context_test.lua /tmp/miuread-reviewed/miuread.koplugin/main.lua
+```
+
+The first and third tests target Kindle/glibc. The fork test performs DNS lookups
+for `weread.qq.com`, but does not call authenticated APIs. Run one instance at a
+time. The navigation and popup tests also run under standalone Lua 5.1/LuaJIT.
+
+Verified on KPW6 with beta22:
+
+- Five regression scripts pass, including navigation after a pending real
+  setting, stale timers, persistence failure/retry, and empty document paths.
+- `python tools/verify_beta22.py`: 292 checks pass.
+- Existing `test_online_comment_likes.lua`, `test_extension_download.lua`,
+  `test_extension_install.lua`, `test_store_shared.lua`, and
+  `test_readtime_recovery.lua` pass. On KOReader, the installer test needs
+  `package.loaded.lfs = require('libs/libkoreader-lfs')` after `setupkoenv`.
+- Original popup metadata preparation took 426–435 ms; matched-document reuse
+  took 0.085–0.170 ms. Subsequent user popup logs recorded 20–49 ms.
+- Original navigation-triggered full settings writes took 2.18–2.32 seconds;
+  five user section-switch samples after deferring navigation writes took
+  355–991 ms, measured through section application with a monotonic clock.
+
+These timings do not include the final physical e-ink refresh. Simulated suspend
+and real fork tests do not prove stability after a long real deep-sleep cycle.
+Navigation positions remain in memory until a lifecycle save or another settings
+write; an abnormal process exit can lose the latest tab/page selection. Reading
+progress persistence is unchanged.

--- a/tools/kpw6_regressions/compact_settings_test.lua
+++ b/tools/kpw6_regressions/compact_settings_test.lua
@@ -1,0 +1,22 @@
+require('setupkoenv')
+local path=assert(arg[1])
+local f=assert(io.open(path)); local source=f:read('*a'); f:close()
+local a=assert(source:find('local function compact_settings(',1,true))
+local b=assert(source:find('local function settings_payload_valid(',a,true))
+local dump=require('dump')
+local payload=assert(loadstring('local dump=...; '..source:sub(a,b-1)..' return settings_payload'))(dump)
+local shared={text='shared'}
+local data={empty={},flag=false,[false]='boolean key',[4]='sparse',[-2]='negative',fraction=1/3,
+ text='中文 "quoted" \\ slash\nnext\r\t\0\255',one=shared,two=shared,nested={a={b='end ]= --'}}}
+local text=payload(data,'test.lua')
+local expected=assert(loadstring('return '..dump(data)))()
+local restored=assert(loadstring(text))()
+assert(dump(restored,nil,true)==dump(expected,nil,true),'compact roundtrip differs from native dump')
+assert(#text < #('return '..dump(data)),'ordinary settings were not compacted')
+local cyclic={name='cycle'}; cyclic.self=cyclic
+assert(payload(cyclic,'test.lua')=='-- test.lua\nreturn '..dump(cyclic)..'\n','cycle fallback changed')
+local key={name='table key'}; local unusual={[key]='value'}
+assert(payload(unusual,'test.lua')=='-- test.lua\nreturn '..dump(unusual)..'\n','table-key fallback changed')
+local unsupported={callback=function() end}
+assert(payload(unsupported,'test.lua')=='-- test.lua\nreturn '..dump(unsupported)..'\n','unsupported value fallback changed')
+print('COMPACT_SETTINGS_NATIVE_COMPATIBILITY_OK')

--- a/tools/kpw6_regressions/fork_test.lua
+++ b/tools/kpw6_regressions/fork_test.lua
@@ -1,0 +1,22 @@
+require('setupkoenv')
+local candidate=arg[1] or 'plugins/miuread.koplugin'
+package.path=candidate..'/?.lua;plugins/miuread.koplugin/?.lua;'..package.path
+local socket=require('socket')
+local H=require('miuread.subprocess_hygiene')
+local F=require('ffi/util')
+local listener=assert(socket.tcp());assert(listener:bind('127.0.0.1',0));assert(listener:listen(1))
+assert(socket.dns.toip('weread.qq.com'))
+local path='/tmp/miuread-resolver-child-test'
+os.remove(path)
+local pid=assert(F.runInSubProcess(function()
+ assert(H.close_inherited_sockets())
+ local f=assert(io.open(path,'w'))
+ local ok=socket.dns.toip('weread.qq.com')
+ assert(ok)
+ assert(f:write('CHILD_DNS_AND_REUSED_FD_OK'));assert(f:close())
+end,false,false))
+for i=1,80 do if F.isSubProcessDone(pid,false) then break end socket.sleep(.1) end
+local f=assert(io.open(path));assert(f:read('*a')=='CHILD_DNS_AND_REUSED_FD_OK');f:close();os.remove(path)
+assert(listener:getsockname());listener:close()
+assert(socket.dns.toip('weread.qq.com'))
+print('FORK_RESOLVER_PARENT_SOCKET_AND_CHILD_FILE_OK')

--- a/tools/kpw6_regressions/full_refresh_test.lua
+++ b/tools/kpw6_regressions/full_refresh_test.lua
@@ -1,0 +1,26 @@
+local f=assert(io.open(assert(arg[1]))); local source=f:read('*a'); f:close()
+local a=assert(source:find('function Plugin:_home_full_refresh(',1,true))
+local b=assert(source:find('\nfunction Plugin:',a+1,true))
+local calls=0
+local env={Plugin={},UIManager={setDirty=function(_,widget,kind)
+    assert(widget==nil and kind=='full'); calls=calls+1
+end},logger={warn=function() end}}
+setmetatable(env,{__index=_G})
+local chunk=assert(loadstring(source:sub(a,b-1)))
+setfenv(chunk,env); chunk()
+local active=nil
+local stale_calls=0
+local host={ui={devicelistener={onFullRefresh=function() stale_calls=stale_calls+1; error('closed document') end}},
+    _active_reader_ui=function() return active end}
+local refresh=env.Plugin._home_full_refresh
+assert(refresh(host,true) and calls==1 and stale_calls==0,'Home used closed Reader listener')
+local reader_calls=0
+active={document={},devicelistener={onFullRefresh=function() reader_calls=reader_calls+1 end}}
+assert(refresh(host,true) and calls==1 and reader_calls==1,'active Reader footer refresh was lost')
+active.document=nil
+assert(refresh(host,true) and calls==2 and reader_calls==1,'closing Reader was refreshed')
+active={document={},devicelistener={onFullRefresh=function() error('listener failure') end}}
+assert(refresh(host,true) and calls==3,'failed native refresh did not repaint')
+active={document={}}
+assert(refresh(host,true) and calls==4,'missing listener did not repaint')
+print('HOME_FULL_REFRESH_LIFECYCLE_OK')

--- a/tools/kpw6_regressions/navigation_test.lua
+++ b/tools/kpw6_regressions/navigation_test.lua
@@ -1,0 +1,57 @@
+local function read(path) local f=assert(io.open(path));local s=f:read('*a');f:close();return s end
+local source=read(assert(arg[1]))
+assert(loadstring(source),'main.lua syntax')
+local function method(name)
+    local a=assert(source:find('function Plugin:'..name..'(',1,true))
+    local b=assert(source:find('\nfunction Plugin:',a+1,true))
+    return source:sub(a,b-1)
+end
+local UI={tasks={}}
+function UI:scheduleIn(delay,task) self.tasks[task]=delay end
+function UI:unschedule(task) self.tasks[task]=nil end
+local code='local UIManager,logger,HomeView,U=...;local Plugin={}\n'
+for _,name in ipairs({'_save_home_preferences_deferred','_pause_home_preferences_flush','_resume_home_preferences_flush','_flush_home_preferences'}) do code=code..method(name)..'\n' end
+local Plugin=assert(loadstring(code..'return Plugin'))(UI,{info=function() end,warn=function() end},{is_shown=function() return true end},{first_line=tostring})
+local writes=0
+local store={preferences=function(self) return self.value end,save_preferences_deferred=function(self,p) self.value=p end,flush=function() writes=writes+1;return true end}
+local host=setmetatable({store=store,_active_reader_ui=function() return false end,_home_ui_busy=function() return false end},{__index=Plugin})
+local function tasks() local n=0;for _ in pairs(UI.tasks) do n=n+1 end;return n end
+local function fire() local t=UI.tasks;UI.tasks={};for fn in pairs(t) do fn() end end
+host:_save_home_preferences_deferred({active_section='shelf'},{},false)
+local stale=function() end
+for _,section in ipairs({'device','recent','shelf','recent'}) do
+    host:_save_home_preferences_deferred({active_section=section},{},false)
+    if arg[2]=='baseline' then fire() else assert(tasks()==0,'navigation must not queue full settings writes') end
+end
+if arg[2]=='baseline' then assert(writes==4);print('BASELINE_NAVIGATION_FULL_WRITES',writes);return end
+stale();assert(writes==0,'stale timer must not flush')
+assert(store.value.home_ui.active_section=='recent')
+host:_pause_home_preferences_flush('reader')
+assert(host:_resume_home_preferences_flush()==false and tasks()==0,'return to home must not rearm navigation flush')
+assert(host:_flush_home_preferences()==true and writes==1,'lifecycle saves latest navigation')
+assert(host:_flush_home_preferences()==false and writes==1,'do not save twice')
+host:_save_home_preferences_deferred({active_section='device',display_size='large'},{},2)
+assert(tasks()==1,'ordinary settings retain timer')
+fire();assert(writes==2 and not host._home_state_save_pending)
+host:_save_home_preferences_deferred({active_section='shelf'},{},false)
+host:_save_home_preferences_deferred({active_section='shelf',display_size='small'},{},2)
+assert(tasks()==1,'a later settings change restores normal persistence');fire();assert(writes==3)
+-- A navigation after a real setting must not cancel that setting's timer.
+host:_save_home_preferences_deferred({active_section='shelf',display_size='large'},{},2)
+local replaced=host._home_state_save_task
+host:_save_home_preferences_deferred({active_section='recent',display_size='large'},{},false)
+assert(tasks()==1 and not host._home_state_save_on_exit)
+replaced();assert(writes==3,'superseded callback must not flush')
+fire();assert(writes==4 and store.value.home_ui.display_size=='large')
+-- Store:flush can restore old disk data on failure; keep pending values retryable.
+host:_save_home_preferences_deferred({active_section='device'},{},false)
+store.flush=function(self) self.value={home_ui={active_section='shelf'}};return false,'simulated disk failure' end
+assert(host:_flush_home_preferences()==false and host._home_state_save_pending)
+assert(store.value.home_ui.active_section=='device','failed flush must preserve intended navigation')
+store.flush=function() writes=writes+1;return true end
+assert(host:_flush_home_preferences()==true and writes==5)
+for _,name in ipairs({'_home_change_page' ,'_home_apply_section','_set_home_section'}) do
+    assert(method(name):find('preferences,false)',1,true),name..' must use navigation persistence')
+end
+assert(method('onSuspend'):find('if self._home_state_save_on_exit then self:_flush_home_preferences() end',1,true))
+print('NAVIGATION_NO_UI_FLUSH_LIFECYCLE_AND_SETTINGS_OK')

--- a/tools/kpw6_regressions/navigation_test.lua
+++ b/tools/kpw6_regressions/navigation_test.lua
@@ -1,5 +1,7 @@
 local function read(path) local f=assert(io.open(path));local s=f:read('*a');f:close();return s end
 local source=read(assert(arg[1]))
+assert(source:find('self.store:save_preferences_deferred(preferences,delay==false)',1,true),
+    'navigation must survive Store reloads from other plugin paths')
 assert(loadstring(source),'main.lua syntax')
 local function method(name)
     local a=assert(source:find('function Plugin:'..name..'(',1,true))

--- a/tools/kpw6_regressions/network_test.lua
+++ b/tools/kpw6_regressions/network_test.lua
@@ -1,0 +1,49 @@
+require('setupkoenv')
+local candidate=arg[1] or 'plugins/miuread.koplugin'
+package.path=candidate..'/?.lua;plugins/miuread.koplugin/?.lua;'..package.path
+local clock=require('socket').gettime
+local function read(path) local f=assert(io.open(path));local s=f:read('*a');f:close();return s end
+local source=read(candidate..'/main.lua')
+local chunk=assert(source:match('(function Plugin:is_online%(%).-)\n%-%- Fast local hint'))
+local Plugin={}
+assert(loadstring('return function(Plugin) '..chunk..' end'))()(Plugin)
+local dns=0
+local network={isWifiOn=function() return true end,isConnected=function() return true end,isOnline=function() dns=dns+1;error('DNS MUST NOT RUN IN UI') end,getCurrentNetwork=function() return {ssid='test'} end}
+package.loaded['ui/network/manager']=network
+local t=clock()
+for i=1,1000 do assert(Plugin:is_online()) end
+assert(dns==0)
+print('PREFLIGHT_1000_MS',(clock()-t)*1000)
+network.isWifiOn=function() return false end;assert(not Plugin:is_online())
+network.isWifiOn=function() return true end;network.isConnected=function() return false end;assert(not Plugin:is_online())
+network.isConnected=function() error('local status unavailable') end;assert(Plugin:is_online())
+network.isConnected=function() return true end
+package.loaded.device={isKindle=function() return true end,getPowerDevice=function() return {getCapacity=function() return 80 end,isCharging=function() return false end} end}
+local health={state='recovering',age=1};local writes=0
+package.loaded['miuread.network_health']={snapshot=function() return health end,note_success=function() writes=writes+1;health={state="ok",age=0} end}
+local Home= require('miuread.home_data')
+t=clock()
+for i=1,1000 do local s=Home.quick_device_state(true);assert(s.network_phase=='connected' and s.online==nil) end
+assert(dns==0);print('QUICK_STATE_1000_MS',(clock()-t)*1000)
+health={state='ok',age=2};assert(Home.quick_device_state(true).online==true);assert(writes==0,'UI must not renew stale health')
+health={state='ok',age=2,reason='network-manager-associated'};assert(Home.quick_device_state(true).online==nil)
+health={state='ok',age=61};assert(Home.quick_device_state(true).online==nil)
+health={state='down',age=2};assert(Home.quick_device_state(true).online==false)
+network.isWifiOn=function() return false end;assert(Home.quick_device_state(true).network_phase=='off')
+assert(dns==0)
+network.isWifiOn=function() return true end;health={state='unknown',age=100}
+network.isOnline=function() dns=dns+1;return true end
+health={state='recovering',age=1}
+local probed=Home.quick_device_state(true,true)
+assert(probed.online==true and probed.network_phase=='connected');assert(dns==1 and writes==1)
+local extension=read(candidate..'/miuread/extension_job.lua')
+local fn=assert(extension:match('(local function network_connected%(%)\n.-\nend)'))
+local connected=assert(loadstring(fn..'\nreturn network_connected'))()
+network.isOnline=function() error('DNS MUST NOT RUN') end
+assert(connected());network.isConnected=function() return false end;assert(not connected())
+local Hygiene=require('miuread.subprocess_hygiene')
+assert(Hygiene.reset_resolver(),'Kindle glibc reset must work')
+local ffi=require('ffi');package.loaded.ffi={cdef=function() end,C={}}
+assert(Hygiene.reset_resolver()==false,'unsupported libc must be safe')
+package.loaded.ffi=ffi
+print('UI_NETWORK_TESTS_OK')

--- a/tools/kpw6_regressions/popup_context_test.lua
+++ b/tools/kpw6_regressions/popup_context_test.lua
@@ -1,0 +1,18 @@
+local f=assert(io.open(assert(arg[1])));local source=f:read('*a');f:close()
+local a=assert(source:find('function Plugin:_thought_favorite_context(',1,true))
+local b=assert(source:find('\nfunction Plugin:',a+1,true))
+local fn=assert(loadstring('local U={trim=function(s) return s end};local Plugin={};'..source:sub(a,b-1)..'\nreturn Plugin._thought_favorite_context'))()
+local record={path='book.epub',book={bookId='test',title='Book',author='Author',catalog={{}}},record={chapter_map={}}}
+local fallback=0
+local host={store={book=function() return record.book end},sync={current=record,_document_path=function() return 'book.epub' end},
+_reader_session_is_weread=function() return true end,_current_book_record=function() fallback=fallback+1;return record end,
+_thought_chapter_title_from_rows=function() return 'Chapter' end}
+local info={book_id='test',chapter_uid='one',range='1-2'}
+local value=fn(host,info);assert(fallback==0 and value.book_title=='Book' and value.chapter_title=='Chapter' and value.range_key=='1-2')
+for _,path in ipairs({'other.epub',''}) do host.sync._document_path=function() return path end;fn(host,info) end
+assert(fallback==2)
+record.path=nil;host.sync._document_path=function() return nil end;fn(host,info);assert(fallback==3)
+record.path='book.epub';host.sync.current=nil;fn(host,info);assert(fallback==4)
+host.sync=nil;fn(host,info);assert(fallback==5)
+host._reader_session_is_weread=function() return false end;fn(host,info);assert(fallback==6)
+print('POPUP_DOCUMENT_MATCH_AND_FALLBACK_OK')

--- a/tools/kpw6_regressions/reader_return_test.lua
+++ b/tools/kpw6_regressions/reader_return_test.lua
@@ -1,0 +1,32 @@
+local f=assert(io.open(assert(arg[1])));local source=f:read('*a');f:close()
+local a=assert(source:find('function Plugin:_request_reader_close(',1,true))
+local b=assert(source:find('\nfunction Plugin:',a+1,true))
+local close={generation=1,state='reader_closing'}
+local shown=true
+local env={Plugin={},READER_CLOSE=close,HomeView={is_shown=function() return shown end},
+ Event={new=function() return {} end},monotonic_wall_time=function() return 100 end,
+ logger={info=function() end,warn=function() end}}
+setmetatable(env,{__index=_G})
+local chunk=assert(loadstring(source:sub(a,b-1)));setfenv(chunk,env);chunk()
+local fn=env.Plugin._request_reader_close
+local state,after_close,fail='active','closed',false
+local saved,finished,scheduled,events=0,0,0,0
+local reader={document={}}
+function reader:handleEvent() events=events+1 end
+function reader:onClose(force)
+ assert(force==false);if fail then error('close failed') end
+ saved=saved+1;state=after_close
+end
+local host={_reader_lifecycle_state=function() return state,reader end,
+ _reader_session_is_local=function() return false end,
+ _finish_reader_return=function() assert(state=='closed' and saved>0);finished=finished+1;return true end,
+ _schedule_reader_return_finish=function() scheduled=scheduled+1 end}
+assert(fn(host,1,'test'));assert(saved==1 and finished==1 and scheduled==0 and events==2)
+for _,phase in ipairs({'active','closing'}) do state='active';after_close=phase;assert(fn(host,1,'test')) end
+assert(saved==3 and finished==1 and scheduled==2,'incomplete close bypassed native settle')
+state='active';after_close='closed';shown=false;assert(fn(host,1,'test'))
+assert(finished==1 and scheduled==3,'missing parked Home bypassed native recovery')
+state='active';shown=true;fail=true;assert(not fn(host,1,'test'))
+assert(finished==1 and scheduled==4,'failed close was treated as complete')
+assert(not fn(host,2,'stale'));assert(scheduled==4 and finished==1)
+print('READER_RETURN_AFTER_CLOSE_AND_FALLBACK_OK')

--- a/tools/kpw6_regressions/service_test.lua
+++ b/tools/kpw6_regressions/service_test.lua
@@ -1,0 +1,43 @@
+require('setupkoenv')
+local candidate=arg[1] or 'plugins/miuread.koplugin'
+package.path=candidate..'/?.lua;plugins/miuread.koplugin/?.lua;'..package.path
+local real_os_time=os.time
+local now=1000
+os.time=function() return now end
+local resets,reports,statuses={},{},{}
+local job={generation=1,book_id='test',core_map_hash='map',record_generation=1,book_path='test.epub',reading_time_session_id='session',reading_time_segment_id='one',interval=60,first_delay=15,time_only=true,book={},auth={}}
+local control={generation=1,book_id='test',core_map_hash='map',record_generation=1,active=true,time_only=true,last_activity=1000}
+local files={job=job,control=control}
+local function copy(v) if type(v)~='table' then return v end local r={} for k,w in pairs(v) do r[k]=copy(w) end return r end
+package.loaded['miuread.json']={decode=function(v) return copy(v) end,encode=function(v) return copy(v) end}
+package.loaded['miuread.util']={copy=copy,read_file=function(p) return files[p] end,atomic_write=function(p,v) files[p]=copy(v);if p=='status' then statuses[#statuses+1]=copy(v) end return true end,file_exists=function() return now>5200 end}
+package.loaded['miuread.subprocess_hygiene']={reset_resolver=function() resets[#resets+1]=now;return true end}
+package.loaded['miuread.legacy_adapter_worker']={run=function(v)
+ reports[#reports+1]={at=now,elapsed=v.elapsed_seconds}
+ if #reports==1 then return {accepted=false,error_kind='transport',error='network timeout'} end
+ if #reports==2 then error('connection timeout') end
+ return {accepted=true}
+end}
+package.loaded.socket={sleep=function()
+ now=now+1
+ if now==1008 then job=copy(job);job.generation=2;files.job=job;control.generation=2 end
+ if now==1250 then control.active=false end
+ if now==1300 then now=4900 end -- one hour asleep
+ if now==5000 then job=copy(job);job.generation=3;job.reading_time_segment_id='two';files.job=job;control.generation=3;control.active=true;control.last_activity=now end
+end}
+local Service=require('miuread.read_report_service')
+assert(Service.run{job_path='job',control_path='control',status_path='status',context_path='context',stop_path='stop'})
+assert(resets[1]==1000 and resets[2]==1015,'metadata refresh must preserve first report clock')
+assert(reports[1].at==1015 and reports[1].elapsed==15)
+assert(reports[2].at>=1075,'transport must keep retry backoff')
+assert(resets[3]==reports[2].at,'raised transport failures reset too')
+assert(resets[4]==5000 and #resets==4,'one reset at resume, none for successful periodic reports')
+local resumed=false
+for _,r in ipairs(reports) do
+ assert(r.elapsed<=60,'no accumulated/suspended-time replay')
+ assert(not(r.at>=1250 and r.at<5000),'must not report while suspended')
+ if r.at==5015 then assert(r.elapsed==15);resumed=true end
+end
+assert(resumed)
+os.time=real_os_time
+print('SERVICE_CLOCK_RETRY_SUSPEND_OK',#reports,'reports',#resets,'resets')

--- a/tools/test_store_shared.lua
+++ b/tools/test_store_shared.lua
@@ -34,8 +34,10 @@ local function read(path)
     local data=f:read('*a'); f:close(); return data
 end
 local fail_write=false
+local write_count=0
 local function write(path,data)
     if fail_write then return false,'simulated write failure' end
+    write_count=write_count+1
     local f=assert(io.open(path,'wb')); f:write(data); f:close(); return true
 end
 local function attributes(path,what)
@@ -122,6 +124,46 @@ local function run()
     assert(home:preferences().home_ui.local_entry_root=='/mnt/us/Other',
         'reload left another plugin instance on stale settings')
 
+    -- Navigation can remain pending while downloads/MP callbacks reload disk.
+    prefs=home:preferences()
+    prefs.home_ui.active_section='recent'
+    prefs.home_ui.page_by_section={recent=3}
+    home:save_preferences_deferred(prefs,true)
+    local downloaded=loadfile(path)()
+    downloaded.library['external-download']={title='New download'}
+    downloaded.preferences.home_ui.display_size='large'
+    assert(write(path,'return '..dump(downloaded)))
+    local reload_writes=write_count
+    reader:reload()
+    assert(write_count==reload_writes+1,'reload added a foreground settings save')
+    assert(home:preferences().home_ui.active_section=='recent',
+        'background reload discarded pending navigation')
+    assert(home:preferences().home_ui.page_by_section.recent==3)
+    assert(home:preferences().home_ui.display_size=='large','navigation hid a disk preference update')
+    assert(home:book('external-download').title=='New download','navigation hid a download result')
+    assert(home:flush())
+    downloaded=loadfile(path)()
+    assert(downloaded.preferences.home_ui.active_section=='recent')
+    downloaded.preferences.home_ui.active_section='device'
+    assert(write(path,'return '..dump(downloaded)))
+    home:reload()
+    assert(home:preferences().home_ui.active_section=='device','saved navigation remained pinned')
+    prefs=home:preferences(); prefs.home_ui.active_section='recent'
+    home:save_preferences_deferred(prefs,true)
+    fail_write=true
+    assert(home:flush()==false)
+    fail_write=false
+    assert(home:preferences().home_ui.active_section=='recent','failed save discarded navigation')
+    home:reload()
+    assert(home:preferences().home_ui.active_section=='recent','failed navigation could not survive reload')
+    assert(home:flush())
+    home:save_preferences_deferred(home:preferences(),true)
+    assert(home:flush()) -- unchanged flush must also release the pending overlay
+    downloaded=loadfile(path)(); downloaded.preferences.home_ui.active_section='shelf'
+    assert(write(path,'return '..dump(downloaded)))
+    home:reload()
+    assert(home:preferences().home_ui.active_section=='shelf','unchanged save retained stale navigation')
+
     -- A newer verified progress state written to disk must beat an older live
     -- pending snapshot when Home later flushes an unrelated preference.
     reader:set_deferred('sessions',{['book-progress']={
@@ -146,6 +188,32 @@ local function run()
         'Home preference flush lost the verified progress terminal state')
     assert(progress_saved.pending_progress==false,
         'Home preference flush resurrected an already verified pending upload')
+
+    local before_writes=write_count
+    assert(home:flush('duplicate_close'))
+    assert(write_count==before_writes,'unchanged close rewrote settings/backups')
+    home.db.data.return_fraction=1/3
+    assert(home:flush())
+    before_writes=write_count
+    assert(home:flush('same_fraction'))
+    assert(write_count==before_writes,'serialized progress fraction caused another full save')
+    home.db.data.return_fraction=nil
+    assert(home:flush())
+    -- Nested in-place changes and deletions must still be durable immediately.
+    home.db.data.return_test={nested={value='new',remove=true},flag=false}
+    assert(home:flush())
+    assert(loadfile(path)().return_test.nested.value=='new')
+    home.db.data.return_test.nested.remove=nil
+    home.db.data.return_test.nested.value='changed'
+    assert(home:flush())
+    local changed=loadfile(path)().return_test
+    assert(changed.nested.remove==nil and changed.nested.value=='changed' and changed.flag==false)
+    home.db.data.return_test=nil
+    assert(home:flush())
+    assert(loadfile(path)().return_test==nil,'deleted table remained on disk')
+    assert(write(path,'invalid settings chunk'))
+    assert(home:flush(),'invalid disk must be repaired, not treated as unchanged')
+    assert(loadfile(path)().preferences.home_ui.local_entry_root=='/mnt/us/Other')
 
     local isolated_options={settings_path=path,data_dir=options.data_dir,isolated=true}
     local isolated=Store:new(isolated_options)


### PR DESCRIPTION
## 问题与改动

基于 5.8.0-beta.22。评论弹窗、主页切换及退出阅读后的操作，会被同步 DNS、重复设置读取和完整设置保存阻塞；主页全屏刷新还可能访问已关闭的 ReaderFooter。

- UI 预检只查本地无线/连接状态，DNS 保留在异步探测和请求进程；唤醒、fork 和阅读服务边界重置可用的 libc 解析器，保留计时、退避和不重放写请求的行为。
- 评论收藏上下文复用与当前文档匹配的记录；空路径、切书或记录缺失保留原回退。
- 标签/分页延后保存，普通设置仍保留正常保存时机。共享 Store 重读时只保留待保存的导航，其他设置、下载和进度正常载入；保存失败保留导航重试，成功后解除保留。
- 设置序列化使用原 dump 相同的 Lua 字面量和数值表示，减少排版空白；特殊数据回退原序列化。保留校验、原子替换、备份和失败恢复；与新读出的磁盘内容相同则跳过重复写入。
- 复用一份已校验的设置内容和解析结果：每次仍读取磁盘完整字节，只有完全一致才复用；写前完整解析、写后逐字节核对。保留原子替换、备份、失败恢复及原有阅读进度保存时机，减少退出后的重复解析。
- 原生 ReaderUI:onClose 完成、阅读器完全关闭且停放主页可用时，立即进入已有受保护的恢复流程，避免后台回调抢在主页恢复定时器之前执行。未完成关闭、缺少主页或关闭报错仍走原等待/恢复路径。
- 全屏刷新使用仍有文档的当前 Reader；主页直接请求 full 重绘，避免调用已关闭阅读器的页脚。

## 验证

- `python tools/verify_beta22.py`：292 项通过。
- 17 组设备 LuaJIT 脚本全部通过：UI DNS、服务计时/休眠/退避、真实 fork DNS/文件描述符、导航、弹窗、全屏刷新、关闭流程、紧凑序列化兼容、共享 Store、设置修复、书架恢复、HTTP keep-alive、点赞 mock、扩展下载、扩展安装/回滚、扩展目录及阅读时长恢复。
- 本次设置优化对应的 PR 源码已通过上述全部 17 组设备回归和 292 项静态检查；新增覆盖同大小同时间的外部进度更新、返回值隔离、有效 Lua 被篡改后的拒绝及恢复。
- 实际设置副本完整保存：1008–1097 ms → 727–779 ms；约 2.8 MB → 1.2 MB，逐值回读一致。
- 前次三次实际日志，从关闭请求到主页恢复为 1285、1599、1641 ms；标签切换样本为 331、489、724 ms，来源切换为 664、920 ms。用户已测试并确认提交。
- 本次实际设置副本：变更保存 802–894 ms → 首次 777 ms、后续 511–616 ms；不变保存 127–244 ms → 48–51 ms，逐值回读一致。单份校验快照在该设置规模下增加约 4.3 MB 常驻内存。
- 首组三轮日志的主页恢复为 1048–1219 ms，分类操作为 178–436 ms，下拉面板为 34–103 ms；这些耗时不包含事件排队，不能视为所有点击的响应上限。
- 已核对最新正式版 v5.7.5：Store 与 beta22 基线相同，重复解析路径早于本 PR。
- 实际测试确认待上传进度可恢复并获得云端确认，后续正常退出的阅读时长和进度同步成功。

测试说明见 `tools/kpw6_regressions/README.md`。提交不含账号、设备设置或原始阅读日志。日志计时不含最终物理墨水屏刷新，也不保证所有场景上限；长期真实深度休眠仍需日常观察。异常强制退出可能丢失最后未保存的标签/页码，阅读进度保存时机没有延后。

kpw3和kpw6测试使用均流畅